### PR TITLE
Outputs stdout and stderr to standard error for debugging purposes

### DIFF
--- a/actions/npm-run/run-npm-command.sh
+++ b/actions/npm-run/run-npm-command.sh
@@ -33,6 +33,17 @@ function run-npm-command() {
   stderr="${stderr//$'\n'/'%0A'}"
   stderr="${stderr//$'\r'/'%0D'}"
 
+  # Dump stdout and stderr for debugging purposes
+  {
+    echo "-------------------- BEGIN STDOUT --------------------"
+    cat "$stdout_file"
+    echo "-------------------- END STDOUT   --------------------"
+
+    echo "-------------------- BEGIN STDERR --------------------"
+    cat "$stderr_file"
+    echo "-------------------- END STDERR   --------------------"
+  } >&2
+
   # Outputs
   echo "::set-output name=stdout::$stdout"
   echo "::set-output name=stderr::$stderr"


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

We do not get stdout or stderr so we do not know the error from npm run command.

## Solution

<!-- How does this change fix the problem? -->

Outputs stdout and stderr both to stderr for debugging purposes within the npm-run action.

## Notes

<!-- Additional notes here -->
