### PR TITLE
Uses the proper output name

### DIFF
--- a/actions/npm-setup/action.yml
+++ b/actions/npm-setup/action.yml
@@ -31,7 +31,7 @@ runs:
       name: 'Setup node'
       uses: actions/setup-node@v2
       with:
-        node-version: ${{ steps.version.outputs.node_version }}
+        node-version: ${{ steps.version.outputs.node-version }}
     -
       name: 'Cache npm dependencies'
       uses: actions/cache@v2


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

The setup-node action is attempting to pull an output that does not exist.

## Solution

<!-- How does this change fix the problem? -->

Sets the proper output name.

## Notes

<!-- Additional notes here -->
