### PR TITLE
Adds setup-go wrapper

### DIFF
--- a/.github/actions/test-setup-go/action.yml
+++ b/.github/actions/test-setup-go/action.yml
@@ -1,0 +1,34 @@
+---
+
+name: 'Test setup-go'
+description: 'Runs validation against the setup-go action'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Install BATS'
+      shell: bash
+      run: brew install bats-core
+
+    - name: 'Checkout actions'
+      uses: actions/checkout@v2
+
+    - name: 'Checkout hello world project'
+      uses: actions/checkout@v2
+      with:
+        repository: mike-carey/hello-world-golang
+        path: ./hello-world
+
+    - name: 'Run setup-go action'
+      id: setup
+      uses: ./actions/setup-go
+      with:
+        go-version: '1.19'
+        working-directory: ./hello-world
+
+    - name: 'Validate'
+      shell: bash
+      run: bats -r ${{ github.action_path }}/setup-go.bats
+      env:
+        DIRECTORY: ./hello-world
+        GO_VERSION: ${{ steps.setup.outputs.go-version }}

--- a/.github/actions/test-setup-go/setup-go.bats
+++ b/.github/actions/test-setup-go/setup-go.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+
+@test "it should have go installed" {
+  run go version
+
+  [ "$status" -eq 0 ]
+}
+
+@test "it should have installed go modules" {
+  [ -d "$GOPATH/src/golang.org/x" ]
+}
+
+@test "it should have passed along the go version" {
+  [ -n "$GO_VERSION" ]
+}

--- a/.github/workflows/test-setup-go.yml
+++ b/.github/workflows/test-setup-go.yml
@@ -1,0 +1,24 @@
+---
+
+name: 'Run setup-go action'
+
+on:
+  pull_request:
+    paths:
+      - actions/setup-go/*
+      - scripts/determine-version.*
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test-setup-go-action:
+    name: 'Uses the setup-go action'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout actions'
+        uses: actions/checkout@v2
+
+      - name: 'Test setup-go action'
+        uses: ./.github/actions/test-setup-go

--- a/actions/setup-go/action.yml
+++ b/actions/setup-go/action.yml
@@ -17,7 +17,7 @@ inputs:
 
 outputs:
   go-version:
-    description: 'The determined node version'
+    description: 'The determined go version'
     value: ${{ steps.version.outputs.version }}
 
 runs:
@@ -29,10 +29,10 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 
-    - name: 'Setup node'
-      uses: actions/setup-go@v2
+    - name: 'Setup go'
+      uses: actions/setup-go@v3
       with:
-        node-version: ${{ steps.version.outputs.version }}
+        go-version: ${{ steps.version.outputs.version }}
         cache: ${{ inputs.cache }}
 
     - name: 'Install gomod dependencies'

--- a/actions/setup-go/action.yml
+++ b/actions/setup-go/action.yml
@@ -1,0 +1,41 @@
+---
+
+name: 'Setup go project'
+description: 'Sets up a go project by installing go and gomod independencies'
+
+inputs:
+  go-version:
+    description: 'The go version to use, defaults to the version specified in .go-version'
+    default: ''
+  working-directory:
+    description: 'The directory to run the setup within'
+    default: '.'
+  cache:
+    description: 'If true, caches dependencies'
+    type: bool
+    default: true
+
+outputs:
+  go-version:
+    description: 'The determined node version'
+    value: ${{ steps.version.outputs.version }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Determine go version'
+      id: version
+      run: ${{ github.action_path }}/determine-version.sh go "${{ inputs.go-version }}"
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+
+    - name: 'Setup node'
+      uses: actions/setup-go@v2
+      with:
+        node-version: ${{ steps.version.outputs.version }}
+        cache: ${{ inputs.cache }}
+
+    - name: 'Install gomod dependencies'
+      run: go mod download
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}

--- a/actions/setup-go/determine-version.sh
+++ b/actions/setup-go/determine-version.sh
@@ -1,0 +1,1 @@
+../../scripts/determine-version.sh


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

We would like a standard setup for go within github actions

## Solution

<!-- How does this change fix the problem? -->

Wraps the setup-go action pulling the go-version file and downloading gomod dependencies.

## Notes

<!-- Additional notes here -->
