### PR TITLE
Removes all outdated set-output commands

### DIFF
--- a/actions/package-archive/package-archive.bats
+++ b/actions/package-archive/package-archive.bats
@@ -3,6 +3,7 @@
 load package-archive.sh
 
 function setup() {
+  export GITHUB_OUTPUT="$BATS_TEST_TMPDIR/output"
   export BUILD_DIRECTORY="$BATS_TEST_TMPDIR/build"
 
   mkdir -p "$BUILD_DIRECTORY"
@@ -32,7 +33,7 @@ function teardown() {
 
   [ "$status" -eq 0 ]
   [ -f "$BATS_TEST_TMPDIR/build.tgz" ]
-  [[ "$output" =~ .*"::set-output name=filename::build.tgz".* ]]
+  grep -q 'filename=build.tgz' "$GITHUB_OUTPUT"
 }
 
 @test "it should use the EXTENSION environment variable for extension" {
@@ -42,7 +43,7 @@ function teardown() {
 
   [ "$status" -eq 0 ]
   [ -f "$BATS_TEST_TMPDIR/build.tar.gz" ]
-  [[ "$output" =~ .*"::set-output name=filename::build.tar.gz".* ]]
+  grep -q 'filename=build.tar.gz' "$GITHUB_OUTPUT"
 }
 
 @test "it should package build directory into gzipped tarball" {
@@ -50,7 +51,7 @@ function teardown() {
 
   [ "$status" -eq 0 ]
   [ -f "$BATS_TEST_TMPDIR/assets.tgz" ]
-  [[ "$output" =~ .*"::set-output name=filename::assets.tgz".* ]]
+  grep -q 'filename=assets.tgz' "$GITHUB_OUTPUT"
 
   mkdir -p "$BATS_TEST_TMPDIR/unpackaged"
   tar -zxf "$BATS_TEST_TMPDIR/assets.tgz" -C "$BATS_TEST_TMPDIR/unpackaged"
@@ -63,7 +64,7 @@ function teardown() {
 
   [ "$status" -eq 0 ]
   [ -f "$BATS_TEST_TMPDIR/assets.tar" ]
-  [[ "$output" =~ .*"::set-output name=filename::assets.tar".* ]]
+  grep -q 'filename=assets.tar' "$GITHUB_OUTPUT"
 
   mkdir -p "$BATS_TEST_TMPDIR/unpackaged"
   tar -xf "$BATS_TEST_TMPDIR/assets.tar" -C "$BATS_TEST_TMPDIR/unpackaged"
@@ -77,7 +78,7 @@ function teardown() {
 
   [ "$status" -eq 0 ]
   [ -f "$BATS_TEST_TMPDIR/assets.zip" ]
-  [[ "$output" =~ .*"::set-output name=filename::assets.zip".* ]]
+  grep -q 'filename=assets.zip' "$GITHUB_OUTPUT"
 
   mkdir -p "$BATS_TEST_TMPDIR/unpackaged"
   unzip "$BATS_TEST_TMPDIR/assets.zip" -d "$BATS_TEST_TMPDIR/unpackaged"

--- a/actions/package-archive/package-archive.sh
+++ b/actions/package-archive/package-archive.sh
@@ -49,7 +49,7 @@ function package-archive() {
       ;;
   esac
 
-  echo "::set-output name=filename::$filename.$extension"
+  echo "filename=$filename.$extension" >> "$GITHUB_OUTPUT"
 }
 
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then

--- a/actions/setup-homebrew/brew-info.bats
+++ b/actions/setup-homebrew/brew-info.bats
@@ -3,6 +3,7 @@
 load brew-info.sh
 
 function setup() {
+  export GITHUB_OUTPUT="$BATS_TEST_TMPDIR/output"
   pushd "$BATS_TEST_TMPDIR" >/dev/null
 }
 
@@ -16,14 +17,14 @@ function teardown() {
   run brew-info Brewfile false
 
   [ "$status" -eq 0 ]
-  [[ "$output" =~ .*"::set-output name=should-install::false".* ]]
+  grep -q 'should-install=false' "$GITHUB_OUTPUT"
 }
 
 @test "it should not indicate to install if the file does not exist" {
   run brew-info Brewfile true
 
   [ "$status" -eq 0 ]
-  [[ "$output" =~ .*"::set-output name=should-install::false".* ]]
+  grep -q 'should-install=false' "$GITHUB_OUTPUT"
 }
 
 @test "it should indicate to install if the file does exist and the install variable is true" {
@@ -32,7 +33,7 @@ function teardown() {
   run brew-info Brewfile true
 
   [ "$status" -eq 0 ]
-  [[ "$output" =~ .*"::set-output name=should-install::true".* ]]
+  grep -q 'should-install=true' "$GITHUB_OUTPUT"
 }
 
 @test "it should output the cache path for homebrew" {
@@ -43,7 +44,7 @@ function teardown() {
   run brew-info Brewfile true
 
   [ "$status" -eq 0 ]
-  [[ "$output" =~ .*"::set-output name=cache-path::${cache_path}".* ]]
+  grep -q "cache-path=$cache_path" "$GITHUB_OUTPUT"
 }
 
 @test "it should output the prefix path for homebrew" {
@@ -54,7 +55,7 @@ function teardown() {
   run brew-info Brewfile true
 
   [ "$status" -eq 0 ]
-  [[ "$output" =~ .*"::set-output name=prefix-path::${prefix_path}".* ]]
+  grep -q "prefix-path=$prefix_path" "$GITHUB_OUTPUT"
 }
 
 @test "it should output the bin paths for homebrew" {
@@ -65,5 +66,5 @@ function teardown() {
   run brew-info Brewfile true
 
   [ "$status" -eq 0 ]
-  [[ "$output" =~ .*"::set-output name=bin-paths::${prefix_path}/bin:${prefix_path}/sbin".* ]]
+  grep -q "bin-paths=$prefix_path/bin:$prefix_path/sbin" "$GITHUB_OUTPUT"
 }

--- a/actions/setup-homebrew/brew-info.sh
+++ b/actions/setup-homebrew/brew-info.sh
@@ -10,16 +10,16 @@ function brew-info() {
   if [ "$install" = true ] && [ -f "$brewfile" ]; then
     should_install=true
   fi
-  echo "::set-output name=should-install::${should_install}"
+  echo "should-install=${should_install}" >> "$GITHUB_OUTPUT"
 
   local cache_path=''
   cache_path="$(brew --cache)"
-  echo "::set-output name=cache-path::${cache_path}"
+  echo "cache-path=${cache_path}" >> "$GITHUB_OUTPUT"
 
   local prefix_path=''
   prefix_path="$(brew --prefix)"
-  echo "::set-output name=prefix-path::${prefix_path}"
-  echo "::set-output name=bin-paths::${prefix_path}/bin:${prefix_path}/sbin"
+  echo "prefix-path=${prefix_path}" >> "$GITHUB_OUTPUT"
+  echo "bin-paths=${prefix_path}/bin:${prefix_path}/sbin" >> "$GITHUB_OUTPUT"
 }
 
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then

--- a/actions/unpack-archive/unpack-archive.bats
+++ b/actions/unpack-archive/unpack-archive.bats
@@ -3,6 +3,8 @@
 load unpack-archive.sh
 
 function setup() {
+  export GITHUB_OUTPUT="$BATS_TEST_TMPDIR/output"
+
   create_archives
 
   export TAR_FILE="$BATS_TEST_TMPDIR/archive.tar"

--- a/actions/unpack-archive/unpack-archive.sh
+++ b/actions/unpack-archive/unpack-archive.sh
@@ -55,8 +55,8 @@ function unpack-archive() {
       ;;
   esac
 
-  echo "::set-output name=destination::$destination"
-  echo "::set-output name=mime-type::$mime"
+  echo "destination=$destination" >> "$GITHUB_OUTPUT"
+  echo "mime-type=$mime" >> "$GITHUB_OUTPUT"
 }
 
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then

--- a/scripts/determine-version.bats
+++ b/scripts/determine-version.bats
@@ -3,6 +3,7 @@
 load determine-version.sh
 
 function setup() {
+  export GITHUB_OUTPUT="$BATS_TEST_TMPDIR/output"
   pushd "$BATS_TEST_TMPDIR" >/dev/null
 }
 
@@ -14,7 +15,7 @@ function teardown() {
   run determine-version - 1.1.1
 
   [ $status -eq 0 ]
-  [[ "$output" =~ .*::set-output\ name=version::1\.1\.1.* ]]
+  grep -q 'version=1.1.1' "$GITHUB_OUTPUT"
 }
 
 @test "it should determine version from version file" {
@@ -23,7 +24,7 @@ function teardown() {
   run determine-version node
 
   [ $status -eq 0 ]
-  [[ "$output" =~ .*::set-output\ name=version::1\.1\.1.* ]]
+  grep -q 'version=1.1.1' "$GITHUB_OUTPUT"
 }
 
 @test "it should determine node version from nvmrc file" {
@@ -32,5 +33,5 @@ function teardown() {
   run determine-version node
 
   [ $status -eq 0 ]
-  [[ "$output" =~ .*::set-output\ name=version::1\.1\.1.* ]]
+  grep -q 'version=1.1.1' "$GITHUB_OUTPUT"
 }

--- a/scripts/determine-version.sh
+++ b/scripts/determine-version.sh
@@ -32,7 +32,7 @@ function determine-version() {
     return 1
   }
 
-  echo "::set-output name=version::$version"
+  echo "version=$version" >> "$GITHUB_OUTPUT"
 }
 
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

Github Actions changed the way to set outputs and state.

## Solution

<!-- How does this change fix the problem? -->

Replaces all

```bash
echo "::set-output name=${name}::${value}"
```

with

```bash
echo "${name}=${value}" >> "$GITHUB_OUTPUT"
```

## Notes

<!-- Additional notes here -->

- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
