### PR TITLE
Adds is-gh-release action

### DIFF
--- a/.github/actions/test-is-gh-release/action.yml
+++ b/.github/actions/test-is-gh-release/action.yml
@@ -41,12 +41,6 @@ runs:
       with:
         ref: v2.0.2
 
-    - name: 'v2.0.2-rc.0: Is GH release?'
-      id: v2_0_2_rc_0
-      uses: ./actions/is-gh-release
-      with:
-        ref: v2.0.2-rc.0
-
     - name: 'Validate'
       shell: bash
       run: bats -r ${{ github.action_path }}/is-gh-release.bats
@@ -54,5 +48,3 @@ runs:
         EMPTY_STRING_IS_RELEASE: ${{ steps.empty_string.outputs.is-release }}
         NOTHERE_IS_RELEASE: ${{ steps.nothere.outputs.is-release }}
         V2_0_2_IS_RELEASE: ${{ steps.v2_0_2.outputs.is-release }}
-        V2_0_2_RC_0_IS_RELEASE: ${{ steps.v2_0_2_rc_0.outputs.is-release }}
-        V2_0_2_RC_0_IS_PRERELEASE: ${{ steps.v2_0_2_rc_0.outputs.is-prerelease }}

--- a/.github/actions/test-is-gh-release/action.yml
+++ b/.github/actions/test-is-gh-release/action.yml
@@ -41,6 +41,12 @@ runs:
       with:
         ref: v2.0.2
 
+    - name: 'v2.0.2-rc.0: Is GH release?'
+      id: v2_0_2_rc_0
+      uses: ./actions/is-gh-release
+      with:
+        ref: v2.0.2-rc.0
+
     - name: 'Validate'
       shell: bash
       run: bats -r ${{ github.action_path }}/is-gh-release.bats
@@ -48,3 +54,5 @@ runs:
         EMPTY_STRING_IS_RELEASE: ${{ steps.empty_string.outputs.is-release }}
         NOTHERE_IS_RELEASE: ${{ steps.nothere.outputs.is-release }}
         V2_0_2_IS_RELEASE: ${{ steps.v2_0_2.outputs.is-release }}
+        V2_0_2_RC_0_IS_RELEASE: ${{ steps.v2_0_2_rc_0.outputs.is-release }}
+        V2_0_2_RC_0_IS_PRERELEASE: ${{ steps.v2_0_2_rc_0.outputs.is-prerelease }}

--- a/.github/actions/test-is-gh-release/action.yml
+++ b/.github/actions/test-is-gh-release/action.yml
@@ -6,7 +6,7 @@ description: 'Runs validation against the is-gh-release action'
 runs:
   using: 'composite'
   steps:
-    - name: 'Install BATS and jq'
+    - name: 'Install BATS'
       shell: bash
       run: |
         # Add brews to the path
@@ -14,7 +14,7 @@ runs:
         # Setup brew environment
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         # Install bats
-        brew install bats-core jq
+        brew install bats-core
 
     - name: 'Checkout'
       uses: actions/checkout@v2

--- a/.github/actions/test-is-gh-release/action.yml
+++ b/.github/actions/test-is-gh-release/action.yml
@@ -39,7 +39,7 @@ runs:
 
     - name: 'Validate'
       shell: bash
-      run: bats -r ${{ github.action_path }}/deploy-to-s3-bucket.bats
+      run: bats -r ${{ github.action_path }}/is-gh-release.bats
       env:
         EMPTY_STRING_IS_RELEASE: ${{ steps.empty_string.outputs.is-release }}
         NOTHERE_IS_RELEASE: ${{ steps.nothere.outputs.is-release }}

--- a/.github/actions/test-is-gh-release/action.yml
+++ b/.github/actions/test-is-gh-release/action.yml
@@ -1,0 +1,46 @@
+---
+
+name: 'Test is-gh-release action'
+description: 'Runs validation against the is-gh-release action'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Install BATS and jq'
+      shell: bash
+      run: |
+        # Add brews to the path
+        echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
+        # Setup brew environment
+        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        # Install bats
+        brew install bats-core jq
+
+    - name: 'Checkout'
+      uses: actions/checkout@v2
+
+    - name: 'Use local actions'
+      uses: ./.github/actions/use-local-actions
+
+    # Empty string
+    - name: 'Empty string: Is GH release?'
+      id: empty_string
+      uses: ./actions/is-gh-release
+
+    # nothere
+    - name: 'nothere: Is GH release?'
+      id: nothere
+      uses: ./actions/is-gh-release
+
+    # v2.0.2
+    - name: 'v2.0.2: Is GH release?'
+      id: v2_0_2
+      uses: ./actions/is-gh-release
+
+    - name: 'Validate'
+      shell: bash
+      run: bats -r ${{ github.action_path }}/deploy-to-s3-bucket.bats
+      env:
+        EMPTY_STRING_IS_RELEASE: ${{ steps.empty_string.outputs.is-release }}
+        NOTHERE_IS_RELEASE: ${{ steps.nothere.outputs.is-release }}
+        V2_0_2_IS_RELEASE: ${{ steps.v2_0_2.outputs.is-release }}

--- a/.github/actions/test-is-gh-release/action.yml
+++ b/.github/actions/test-is-gh-release/action.yml
@@ -31,11 +31,15 @@ runs:
     - name: 'nothere: Is GH release?'
       id: nothere
       uses: ./actions/is-gh-release
+      with:
+        ref: nothere
 
     # v2.0.2
     - name: 'v2.0.2: Is GH release?'
       id: v2_0_2
       uses: ./actions/is-gh-release
+      with:
+        ref: v2.0.2
 
     - name: 'Validate'
       shell: bash

--- a/.github/actions/test-is-gh-release/is-gh-release.bats
+++ b/.github/actions/test-is-gh-release/is-gh-release.bats
@@ -25,15 +25,3 @@ function teardown() {
 
   [ "$status" -eq 0 ]
 }
-
-@test "it should consider v2.0.2-rc.0 a prerelease" {
-  run [ "$V2_0_2_RC_0_IS_PRERELEASE" = 'true' ]
-
-  [ "$status" -eq 0 ]
-}
-
-@test "it should not consider v2.0.2 a release" {
-  run [ "$V2_0_2_RC_0_IS_RELEASE" = 'false' ]
-
-  [ "$status" -eq 0 ]
-}

--- a/.github/actions/test-is-gh-release/is-gh-release.bats
+++ b/.github/actions/test-is-gh-release/is-gh-release.bats
@@ -25,3 +25,15 @@ function teardown() {
 
   [ "$status" -eq 0 ]
 }
+
+@test "it should consider v2.0.2-rc.0 a prerelease" {
+  run [ "$V2_0_2_RC_0_IS_PRERELEASE" = 'true' ]
+
+  [ "$status" -eq 0 ]
+}
+
+@test "it should not consider v2.0.2 a release" {
+  run [ "$V2_0_2_RC_0_IS_RELEASE" = 'false' ]
+
+  [ "$status" -eq 0 ]
+}

--- a/.github/actions/test-is-gh-release/is-gh-release.bats
+++ b/.github/actions/test-is-gh-release/is-gh-release.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+function setup() {
+  :
+}
+
+function teardown() {
+  :
+}
+
+@test "it should not consider empty string a release" {
+  run [ "$EMPTY_STRING_IS_RELEASE" = 'false' ]
+
+  [ "$status" -eq 0 ]
+}
+
+@test "it should not consider 'nothere' a release" {
+  run [ "$NOTHERE_IS_RELEASE" = 'false' ]
+
+  [ "$status" -eq 0 ]
+}
+
+@test "it should consider v2.0.2 a release" {
+  run [ "$V2_0_2_IS_RELEASE" = 'true' ]
+
+  [ "$status" -eq 0 ]
+}

--- a/.github/workflows/test-is-gh-release.yml
+++ b/.github/workflows/test-is-gh-release.yml
@@ -19,5 +19,5 @@ jobs:
       - name: 'Checkout actions'
         uses: actions/checkout@v2
 
-      - name: 'Test setup-brew action'
+      - name: 'Test is-gh-release action'
         uses: ./.github/actions/test-is-gh-release

--- a/.github/workflows/test-is-gh-release.yml
+++ b/.github/workflows/test-is-gh-release.yml
@@ -1,0 +1,23 @@
+---
+
+name: 'Run is-gh-release action'
+
+on:
+  pull_request:
+    paths:
+      - actions/is-gh-release/*
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test-is-gh-release-action:
+    name: 'Uses the is-gh-release action'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout actions'
+        uses: actions/checkout@v2
+
+      - name: 'Test setup-brew action'
+        uses: ./.github/actions/test-is-gh-release

--- a/actions/is-gh-release/action.yml
+++ b/actions/is-gh-release/action.yml
@@ -22,3 +22,5 @@ runs:
       id: is_gh_release
       shell: bash
       run: ${{ github.action_path }}/is-gh-release.sh "${{ inputs.ref }}"
+      env:
+        GH_TOKEN: ${{ github.token }}

--- a/actions/is-gh-release/action.yml
+++ b/actions/is-gh-release/action.yml
@@ -14,6 +14,9 @@ outputs:
   is-release:
     description: 'Returns true if the ref provided is a github release and false otherwise'
     value: ${{ steps.is_gh_release.outputs.is-release }}
+  is-prerelease:
+    description: 'Returns true if the ref provided is a github prerelease and false otherwise'
+    value: ${{ steps.is_gh_release.outputs.is-prerelease }}
 
 runs:
   using: 'composite'

--- a/actions/is-gh-release/action.yml
+++ b/actions/is-gh-release/action.yml
@@ -1,0 +1,24 @@
+---
+
+name: 'Is Github release?'
+description: 'Determines if a version string provided from user input is a github release or not'
+
+inputs:
+  ref:
+    description: 'The ref to check whether or not it is a release'
+    required: true
+    type: string
+    default: ''
+
+outputs:
+  is-release:
+    description: 'Returns true if the ref provided is a github release and false otherwise'
+    value: ${{ steps.is_gh_release.outputs.is-release }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Is Github release?'
+      id: is_gh_release
+      shell: bash
+      run: ${{ github.action_path }}/is-gh-release.sh "${{ inputs.ref }}"

--- a/actions/is-gh-release/action.yml
+++ b/actions/is-gh-release/action.yml
@@ -14,9 +14,6 @@ outputs:
   is-release:
     description: 'Returns true if the ref provided is a github release and false otherwise'
     value: ${{ steps.is_gh_release.outputs.is-release }}
-  is-prerelease:
-    description: 'Returns true if the ref provided is a github prerelease and false otherwise'
-    value: ${{ steps.is_gh_release.outputs.is-prerelease }}
 
 runs:
   using: 'composite'

--- a/actions/is-gh-release/is-gh-release.bats
+++ b/actions/is-gh-release/is-gh-release.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+load is-gh-release.sh
+
+function setup() {
+  export GH_CMD_FILE="$BATS_TEST_TMPDIR/gh.cmd"
+  export GITHUB_OUTPUT="$BATS_TEST_TMPDIR/output"
+}
+
+function teardown() {
+  :
+}
+
+function gh() {
+  echo "$*" >> "$GH_CMD_FILE"
+  if [ "$1 $2" = "release view" ]; then
+    if [[ "$3" =~ v.* ]]; then
+      echo "release found"
+      # gh actually outputs the release notes,
+      # but we do not make use of any of it
+    else
+      echo "release not found"
+      return 1
+    fi
+  fi
+}
+
+@test "it should not consider a blank string a release" {
+  run is-gh-release
+}
+
+@test "it should not consider a release if the gh cli says it is not found" {
+  run is-gh-release nothere
+
+  [ "$status" -eq 0 ]
+  [ -f "$GITHUB_OUTPUT" ]
+  [ "$(< "$GITHUB_OUTPUT")" = 'is-release=false' ]
+}
+
+@test "it should consider a release if the gh cli says it is found" {
+  run is-gh-release v1.0.0
+
+  [ "$status" -eq 0 ]
+  [ -f "$GITHUB_OUTPUT" ]
+  [ "$(< "$GITHUB_OUTPUT")" = 'is-release=true' ]
+}

--- a/actions/is-gh-release/is-gh-release.bats
+++ b/actions/is-gh-release/is-gh-release.bats
@@ -14,7 +14,7 @@ function teardown() {
 function gh() {
   echo "$*" >> "$GH_CMD_FILE"
   if [ "$1 $2" = "release view" ]; then
-    if [ "$3" = v1.0.0 ]; then
+    if [[ "$3" =~ v.* ]]; then
       echo "release found"
       # gh actually outputs the release notes,
       # but we do not make use of any of it
@@ -22,19 +22,11 @@ function gh() {
       echo "release not found"
       return 1
     fi
-  elif [ "$1 $2" = "release list" ]; then
-    local tab=$'\t'
-    echo "v1.0.1-rc.9: January 17, 2023 11:45 AM${tab}Pre-release${tab}v1.0.1-rc.9${tab}about 12 minutes ago
-December 13 AM - First Release${tab}Latest${tab}v1.0.0${tab}about 1 month ago"
   fi
 }
 
 @test "it should not consider a blank string a release" {
   run is-gh-release
-
-  [ "$status" -eq 0 ]
-  [ -f "$GITHUB_OUTPUT" ]
-  grep -q 'is-release=false' "$GITHUB_OUTPUT"
 }
 
 @test "it should not consider a release if the gh cli says it is not found" {
@@ -42,7 +34,7 @@ December 13 AM - First Release${tab}Latest${tab}v1.0.0${tab}about 1 month ago"
 
   [ "$status" -eq 0 ]
   [ -f "$GITHUB_OUTPUT" ]
-  grep -q 'is-release=false' "$GITHUB_OUTPUT"
+  [ "$(< "$GITHUB_OUTPUT")" = 'is-release=false' ]
 }
 
 @test "it should consider a release if the gh cli says it is found" {
@@ -50,23 +42,5 @@ December 13 AM - First Release${tab}Latest${tab}v1.0.0${tab}about 1 month ago"
 
   [ "$status" -eq 0 ]
   [ -f "$GITHUB_OUTPUT" ]
-  grep -q 'is-release=true' "$GITHUB_OUTPUT"
-}
-
-@test "it should consider a prerelease if the gh cli lists it but not found it with view" {
-  run is-gh-release v1.0.1-rc.9
-
-  [ "$status" -eq 0 ]
-  [ -f "$GITHUB_OUTPUT" ]
-  grep -q 'is-release=false' "$GITHUB_OUTPUT"
-  grep -q 'is-prerelease=true' "$GITHUB_OUTPUT"
-}
-
-@test "it should not consider it a prerelease if the gh cli does not list it" {
-  run is-gh-release v1.0.1-rc.8
-
-  [ "$status" -eq 0 ]
-  [ -f "$GITHUB_OUTPUT" ]
-  grep -q 'is-release=false' "$GITHUB_OUTPUT"
-  grep -q 'is-prerelease=false' "$GITHUB_OUTPUT"
+  [ "$(< "$GITHUB_OUTPUT")" = 'is-release=true' ]
 }

--- a/actions/is-gh-release/is-gh-release.bats
+++ b/actions/is-gh-release/is-gh-release.bats
@@ -14,7 +14,7 @@ function teardown() {
 function gh() {
   echo "$*" >> "$GH_CMD_FILE"
   if [ "$1 $2" = "release view" ]; then
-    if [[ "$3" =~ v.* ]]; then
+    if [ "$3" = v1.0.0 ]; then
       echo "release found"
       # gh actually outputs the release notes,
       # but we do not make use of any of it
@@ -22,11 +22,19 @@ function gh() {
       echo "release not found"
       return 1
     fi
+  elif [ "$1 $2" = "release list" ]; then
+    local tab=$'\t'
+    echo "v1.0.1-rc.9: January 17, 2023 11:45 AM${tab}Pre-release${tab}v1.0.1-rc.9${tab}about 12 minutes ago
+December 13 AM - First Release${tab}Latest${tab}v1.0.0${tab}about 1 month ago"
   fi
 }
 
 @test "it should not consider a blank string a release" {
   run is-gh-release
+
+  [ "$status" -eq 0 ]
+  [ -f "$GITHUB_OUTPUT" ]
+  grep -q 'is-release=false' "$GITHUB_OUTPUT"
 }
 
 @test "it should not consider a release if the gh cli says it is not found" {
@@ -34,7 +42,7 @@ function gh() {
 
   [ "$status" -eq 0 ]
   [ -f "$GITHUB_OUTPUT" ]
-  [ "$(< "$GITHUB_OUTPUT")" = 'is-release=false' ]
+  grep -q 'is-release=false' "$GITHUB_OUTPUT"
 }
 
 @test "it should consider a release if the gh cli says it is found" {
@@ -42,5 +50,23 @@ function gh() {
 
   [ "$status" -eq 0 ]
   [ -f "$GITHUB_OUTPUT" ]
-  [ "$(< "$GITHUB_OUTPUT")" = 'is-release=true' ]
+  grep -q 'is-release=true' "$GITHUB_OUTPUT"
+}
+
+@test "it should consider a prerelease if the gh cli lists it but not found it with view" {
+  run is-gh-release v1.0.1-rc.9
+
+  [ "$status" -eq 0 ]
+  [ -f "$GITHUB_OUTPUT" ]
+  grep -q 'is-release=false' "$GITHUB_OUTPUT"
+  grep -q 'is-prerelease=true' "$GITHUB_OUTPUT"
+}
+
+@test "it should not consider it a prerelease if the gh cli does not list it" {
+  run is-gh-release v1.0.1-rc.8
+
+  [ "$status" -eq 0 ]
+  [ -f "$GITHUB_OUTPUT" ]
+  grep -q 'is-release=false' "$GITHUB_OUTPUT"
+  grep -q 'is-prerelease=false' "$GITHUB_OUTPUT"
 }

--- a/actions/is-gh-release/is-gh-release.sh
+++ b/actions/is-gh-release/is-gh-release.sh
@@ -3,30 +3,17 @@
 function is-gh-release() {
   local ref="${1:-}"
   local is_release=false
-  local is_prerelease=false
 
   if [ -n "$ref" ]; then
     if gh release view "$ref"; then
       echo "::debug::The $ref ref is a release"
       is_release=true
     else
-      echo "::debug::Checking for a prerelease"
-      local releases=()
-      while IFS='' read -r line; do
-        releases+=("$line")
-      done < <(gh release list | awk -F'\t' '{print $3}')
-
-      if [[ " ${releases[*]} " =~ .*\ "$ref"\ .* ]]; then
-        echo "::debug::The $ref ref is a prerelease"
-        is_prerelease=true
-      else
-        echo "::debug::The $ref ref is not a release"
-      fi
+      echo "::debug::The $ref ref is not a release"
     fi
   fi
 
   echo "is-release=$is_release" >> "$GITHUB_OUTPUT"
-  echo "is-prerelease=$is_prerelease" >> "$GITHUB_OUTPUT"
 }
 
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then

--- a/actions/is-gh-release/is-gh-release.sh
+++ b/actions/is-gh-release/is-gh-release.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+function is-gh-release() {
+  local ref="${1:-}"
+  local is_release=false
+
+  if [ -n "$ref" ]; then
+    if gh release view "$ref"; then
+      echo "::debug::The $ref ref is a release"
+      is_release=true
+    else
+      echo "::debug::The $ref ref is not a release"
+    fi
+  fi
+
+  echo "is-release=$is_release" >> "$GITHUB_OUTPUT"
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  set -u
+
+  is-gh-release "${@:-}"
+  exit $?
+fi

--- a/actions/is-gh-release/is-gh-release.sh
+++ b/actions/is-gh-release/is-gh-release.sh
@@ -3,17 +3,30 @@
 function is-gh-release() {
   local ref="${1:-}"
   local is_release=false
+  local is_prerelease=false
 
   if [ -n "$ref" ]; then
     if gh release view "$ref"; then
       echo "::debug::The $ref ref is a release"
       is_release=true
     else
-      echo "::debug::The $ref ref is not a release"
+      echo "::debug::Checking for a prerelease"
+      local releases=()
+      while IFS='' read -r line; do
+        releases+=("$line")
+      done < <(gh release list | awk -F'\t' '{print $3}')
+
+      if [[ " ${releases[*]} " =~ .*\ "$ref"\ .* ]]; then
+        echo "::debug::The $ref ref is a prerelease"
+        is_prerelease=true
+      else
+        echo "::debug::The $ref ref is not a release"
+      fi
     fi
   fi
 
   echo "is-release=$is_release" >> "$GITHUB_OUTPUT"
+  echo "is-prerelease=$is_prerelease" >> "$GITHUB_OUTPUT"
 }
 
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

We would like to know if a provided ref is a Github release.

## Solution

<!-- How does this change fix the problem? -->

Adds a simple action to test a string against the gh cli to determine if the ref is a release.

## Notes

<!-- Additional notes here -->
