### PR TITLE
Sets default shell in build-ecr-image

### DIFF
--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -216,6 +216,10 @@ env:
   DOCKER_IMAGE: ${{ secrets.aws-account-id }}.dkr.ecr.${{ inputs.aws-region }}.amazonaws.com/${{ inputs.repository-name }}
   DEPLOY_IAM_ROLE: arn:aws:iam::${{ secrets.aws-account-id }}:role/${{ inputs.role-name }}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build-docker-image:
     name: 'Build docker image'


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

Workflows require the shell to be set or a default.

## Solution

<!-- How does this change fix the problem? -->

Sets the defaults for the shell.

## Notes

<!-- Additional notes here -->
