### PR TITLE
Adds action for tagging ecs resources

### DIFF
--- a/.github/actions/test-render-task-definition/action.yml
+++ b/.github/actions/test-render-task-definition/action.yml
@@ -1,0 +1,28 @@
+---
+
+name: 'Test build-ecr-image workflow'
+description: 'Runs validation against the build-ecr-image workflow'
+
+inputs:
+  ref:
+    description: 'The github ref to expect'
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Setup brew'
+      uses: Homebrew/actions/setup-homebrew@master
+
+    - name: 'Install BATS'
+      shell: bash
+      run: brew install bats-core
+
+    - name: 'Checkout'
+      uses: actions/checkout@v3
+
+    - name: 'Validate'
+      shell: bash
+      run: bats --verbose-run -r ${{ github.action_path }}/render-task-definition.bats
+      env:
+        VERSION_TAG: ${{ inputs.ref || github.sha }}

--- a/.github/actions/test-render-task-definition/action.yml
+++ b/.github/actions/test-render-task-definition/action.yml
@@ -21,6 +21,11 @@ runs:
     - name: 'Checkout'
       uses: actions/checkout@v3
 
+    - name: 'Download task-definition'
+      uses: actions/download-artifact@v2
+      with:
+        name: task-definition
+
     - name: 'Validate'
       shell: bash
       run: bats --verbose-run -r ${{ github.action_path }}/render-task-definition.bats

--- a/.github/actions/test-render-task-definition/customize.py
+++ b/.github/actions/test-render-task-definition/customize.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+""" Setup configurations for the j2cli
+
+:see: https://github.com/kolypto/j2cli#customization
+"""
+
+import yaml
+import os
+
+# Loader
+try:
+    # PyYAML 5.1 supports FullLoader
+    Loader = yaml.FullLoader
+except AttributeError:
+    # Have to use SafeLoader for older versions
+    Loader = yaml.SafeLoader
+
+__DIR__ = os.path.dirname(os.path.realpath(__file__))
+
+
+def alter_context(context):
+    """ Modify the context and return it """
+    context.update({'default': 'yes'})
+    return context

--- a/.github/actions/test-render-task-definition/data.yml
+++ b/.github/actions/test-render-task-definition/data.yml
@@ -1,0 +1,3 @@
+---
+
+application: test-render-task-definition

--- a/.github/actions/test-render-task-definition/expected.yml
+++ b/.github/actions/test-render-task-definition/expected.yml
@@ -1,8 +1,8 @@
 ---
 
 family: test-render-task-definition
-taskRoleArn: arn:aws:iam::{{ account_id }}:role/test-render-task-definition-task
-executionRoleArn: arn:aws:iam::{{ account_id }}:role/test-render-task-definition-execution
+taskRoleArn: arn:aws:iam::1111111111:role/test-render-task-definition-task
+executionRoleArn: arn:aws:iam::1111111111:role/test-render-task-definition-execution
 networkMode: awsvpc
 cpu: '256'
 memory: '1024'

--- a/.github/actions/test-render-task-definition/expected.yml
+++ b/.github/actions/test-render-task-definition/expected.yml
@@ -1,0 +1,31 @@
+---
+
+family: test-render-task-definition
+taskRoleArn: arn:aws:iam::{{ account_id }}:role/test-render-task-definition-task
+executionRoleArn: arn:aws:iam::{{ account_id }}:role/test-render-task-definition-execution
+networkMode: awsvpc
+cpu: '256'
+memory: '1024'
+containerDefinitions:
+- name: test-render-task-definition
+  image: alpine:latest
+  command: [tail, -f, /dev/null]
+  essential: true
+  logConfiguration:
+    logDriver: awslogs
+    options:
+      awslogs-group: test-render-task-definition
+      awslogs-region: us-east-1
+      awslogs-stream-prefix: test-render-task-definition
+  environment:
+    - name: APPLICATION
+      value: test-render-task-definition
+    - name: APP_VERSION
+      value: '{{ tag }}'
+  dockerLabels:
+    application: test-render-task-definition
+    version: '{{ tag }}'
+    default: yes
+requiresCompatibilities:
+  - EC2
+  - FARGATE

--- a/.github/actions/test-render-task-definition/render-task-definition.bats
+++ b/.github/actions/test-render-task-definition/render-task-definition.bats
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+
+function setup() {
+  :
+}
+
+function teardown() {
+  :
+}
+
+@test "it should have rendered the expected task-definition.yml" {
+  sed 's/{{ tag }}/'"$VERSION_TAG"/g "$BATS_TEST_DIRECTORY/expected.yml" > "$BATS_TEST_TMPDIR/expected.yml"
+
+  run diff -y "$BATS_TEST_TMPDIR/expected.yml" task-definition.yml
+
+  [ "$status" -eq 0 ]
+}

--- a/.github/actions/test-render-task-definition/render-task-definition.bats
+++ b/.github/actions/test-render-task-definition/render-task-definition.bats
@@ -9,7 +9,7 @@ function teardown() {
 }
 
 @test "it should have rendered the expected task-definition.yml" {
-  sed 's/{{ tag }}/'"$VERSION_TAG"/g "$BATS_TEST_DIRECTORY/expected.yml" > "$BATS_TEST_TMPDIR/expected.yml"
+  sed 's/{{ tag }}/'"$VERSION_TAG"/g "$BATS_TEST_DIRNAME/expected.yml" > "$BATS_TEST_TMPDIR/expected.yml"
 
   run diff -y "$BATS_TEST_TMPDIR/expected.yml" task-definition.yml
 

--- a/.github/actions/test-render-task-definition/task-definition.yml.j2
+++ b/.github/actions/test-render-task-definition/task-definition.yml.j2
@@ -25,10 +25,10 @@ containerDefinitions:
     - name: APPLICATION
       value: {{ application }}
     - name: APP_VERSION
-      value: {{ tag }}
+      value: '{{ tag }}'
   dockerLabels:
     application: {{ application }}
-    version: {{ tag }}
+    version: '{{ tag }}'
     default: {{ default }}
 requiresCompatibilities:
   - EC2

--- a/.github/actions/test-render-task-definition/task-definition.yml.j2
+++ b/.github/actions/test-render-task-definition/task-definition.yml.j2
@@ -1,0 +1,35 @@
+{%- set tag=env('TAG', default='latest') -%}
+{%- set account_id=env('AWS_ACCOUNT_ID', default=account_id) -%}
+{%- set region=env('AWS_REGION', default='') -%}
+{%- set region=region if region != '' else 'us-east-1' -%}
+---
+
+family: {{ application }}
+taskRoleArn: arn:aws:iam::{{ account_id }}:role/{{ application }}-task
+executionRoleArn: arn:aws:iam::{{ account_id }}:role/{{ application }}-execution
+networkMode: awsvpc
+cpu: '256'
+memory: '1024'
+containerDefinitions:
+- name: {{ application }}
+  image: alpine:latest
+  command: [tail, -f, /dev/null]
+  essential: true
+  logConfiguration:
+    logDriver: awslogs
+    options:
+      awslogs-group: {{ application }}
+      awslogs-region: {{ region }}
+      awslogs-stream-prefix: {{ application }}
+  environment:
+    - name: APPLICATION
+      value: {{ application }}
+    - name: APP_VERSION
+      value: {{ tag }}
+  dockerLabels:
+    application: {{ application }}
+    version: {{ tag }}
+    default: {{ default }}
+requiresCompatibilities:
+  - EC2
+  - FARGATE

--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -216,10 +216,6 @@ env:
   DOCKER_IMAGE: ${{ secrets.aws-account-id }}.dkr.ecr.${{ inputs.aws-region }}.amazonaws.com/${{ inputs.repository-name }}
   DEPLOY_IAM_ROLE: arn:aws:iam::${{ secrets.aws-account-id }}:role/${{ inputs.role-name }}
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   build-docker-image:
     name: 'Build docker image'

--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -216,6 +216,10 @@ env:
   DOCKER_IMAGE: ${{ secrets.aws-account-id }}.dkr.ecr.${{ inputs.aws-region }}.amazonaws.com/${{ inputs.repository-name }}
   DEPLOY_IAM_ROLE: arn:aws:iam::${{ secrets.aws-account-id }}:role/${{ inputs.role-name }}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build-docker-image:
     name: 'Build docker image'

--- a/.github/workflows/render-task-definition.yml
+++ b/.github/workflows/render-task-definition.yml
@@ -18,13 +18,16 @@ on:
       # begin shopsmart/render-j2-action inputs
       template:
         description: 'The path to the template file to render'
+        type: string
         required: true
       data:
         description: 'The path to the file with data to pass to the render'
+        type: string
         required: false
         default: ''
       format:
         description: 'The format the data file will be in'
+        type: string
         required: false
         default: ''
       environment:
@@ -35,26 +38,32 @@ on:
             environment: |
               FOO=bar
               BAR=baz
+        type: string
         required: false
         default: ''
       filters:
         description: 'Load custom Jinja2 filters from a Python file: all top-level functions are imported.'
+        type: string
         required: false
         default: ''
       tests:
         description: 'Load custom Jinja2 tests from a Python file.'
+        type: string
         required: false
         default: ''
       customize:
         description: 'A Python file that implements hooks to fine-tune the j2cli behavior'
+        type: string
         required: false
         default: ''
       undefined:
         description: 'If true, undefined variables will be used in templates (no error will be raised)'
+        type: string
         required: false
         default: 'false'
       output:
         description: 'The name of the output file to write rendered contents to'
+        type: string
         required: false
         default: 'task-definition.yml' # Changed default
       # end shopsmart/render-j2-action inputs

--- a/.github/workflows/render-task-definition.yml
+++ b/.github/workflows/render-task-definition.yml
@@ -94,7 +94,7 @@ jobs:
           format: ${{ inputs.format }}
           env_vars: |
             TAG=${{ inputs.ref }}
-            AWS_ACCOUNT_ID=${{ secrets.aws-account }}
+            AWS_ACCOUNT_ID=${{ secrets.aws-account-id }}
             AWS_REGION=${{ inputs.aws-region }}
             ${{ inputs.environment }}
           filters: ${{ inputs.filters }}

--- a/.github/workflows/render-task-definition.yml
+++ b/.github/workflows/render-task-definition.yml
@@ -80,6 +80,7 @@ defaults:
 jobs:
   render-task-definition:
     name: 'Render task definition'
+    runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/render-task-definition.yml
+++ b/.github/workflows/render-task-definition.yml
@@ -1,0 +1,101 @@
+---
+
+name: 'Render task definition'
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'The branch/sha/tag to render the task definition from'
+        type: string
+        default: ''
+
+      aws-region:
+        description: 'The aws region where resources live'
+        type: string
+        default: us-east-1
+
+      # begin shopsmart/render-j2-action inputs
+      template:
+        description: 'The path to the template file to render'
+        required: true
+      data:
+        description: 'The path to the file with data to pass to the render'
+        required: false
+        default: ''
+      format:
+        description: 'The format the data file will be in'
+        required: false
+        default: ''
+      environment:
+        description: |
+          The environment variables to pass to the render.  Each environment
+          variable should be in format VAR=VAL with one on each line.
+          Example:
+            environment: |
+              FOO=bar
+              BAR=baz
+        required: false
+        default: ''
+      filters:
+        description: 'Load custom Jinja2 filters from a Python file: all top-level functions are imported.'
+        required: false
+        default: ''
+      tests:
+        description: 'Load custom Jinja2 tests from a Python file.'
+        required: false
+        default: ''
+      customize:
+        description: 'A Python file that implements hooks to fine-tune the j2cli behavior'
+        required: false
+        default: ''
+      undefined:
+        description: 'If true, undefined variables will be used in templates (no error will be raised)'
+        required: false
+        default: 'false'
+      output:
+        description: 'The name of the output file to write rendered contents to'
+        required: false
+        default: 'task-definition.yml' # Changed default
+      # end shopsmart/render-j2-action inputs
+
+      secrets:
+        aws-account-id:
+          description: 'The AWS account id that the ecr repository lives under'
+          required: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  render-task-definition:
+    name: 'Render task definition'
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: 'Render task definition'
+        uses: shopsmart/render-j2-action@v1
+        with:
+          template: ${{ inputs.template }}
+          data: ${{ inputs.data }}
+          format: ${{ inputs.format }}
+          env_vars: |
+            TAG=${{ inputs.ref }}
+            AWS_ACCOUNT_ID=${{ secrets.aws-account }}
+            AWS_REGION=${{ inputs.aws-region }}
+            ${{ inputs.environment }}
+          filters: ${{ inputs.filters }}
+          tests: ${{ inputs.tests }}
+          customize: ${{ inputs.customize }}
+          undefined: ${{ inputs.undefined }}
+          output: ${{ inputs.output }}
+
+      - name: 'Upload task definition'
+        uses: actions/upload-artifact@v2
+        with:
+          name: task-definition
+          path: ${{ inputs.output }}

--- a/.github/workflows/render-task-definition.yml
+++ b/.github/workflows/render-task-definition.yml
@@ -68,10 +68,10 @@ on:
         default: 'task-definition.yml' # Changed default
       # end shopsmart/render-j2-action inputs
 
-      secrets:
-        aws-account-id:
-          description: 'The AWS account id that the ecr repository lives under'
-          required: true
+    secrets:
+      aws-account-id:
+        description: 'The AWS account id that the ecr repository lives under'
+        required: true
 
 defaults:
   run:

--- a/.github/workflows/test-render-task-definition.yml
+++ b/.github/workflows/test-render-task-definition.yml
@@ -40,5 +40,4 @@ jobs:
       - name: 'Test render-task-definition workflow'
         uses: ./.github/actions/test-render-task-definition
         with:
-          aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
           ref: ${{ github.sha }}

--- a/.github/workflows/test-render-task-definition.yml
+++ b/.github/workflows/test-render-task-definition.yml
@@ -26,7 +26,7 @@ jobs:
       customize: .github/actions/test-render-task-definition/customize.py
       environment: TAG=${{ github.sha }}
     secrets:
-      aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
+      aws-account-id: '1111111111'
 
   test-render-task-definition-workflow:
     name: 'Uses the render-task-definition workflow'

--- a/.github/workflows/test-render-task-definition.yml
+++ b/.github/workflows/test-render-task-definition.yml
@@ -1,0 +1,44 @@
+---
+
+name: 'Run render-task-definition workflow'
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/render-task-definition.yml
+      - .github/actions/test-render-task-definition/*
+
+permissions:
+  id-token: write # aws auth
+  contents: write # publish release assets
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Build for Branch
+  run-render-task-definition-workflow:
+    uses: ./.github/workflows/render-task-definition.yml
+    with:
+      template: .github/actions/test-render-task-definition/task-definition.yml.j2
+      data: .github/actions/test-render-task-definition/data.yml
+      customize: .github/actions/test-render-task-definition/customize.py
+      environment: TAG=${{ github.sha }}
+      role-name: github-actions-tests
+    secrets:
+      aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
+
+  test-render-task-definition-workflow:
+    name: 'Uses the render-task-definition workflow'
+    runs-on: ubuntu-latest
+    needs: run-render-task-definition-workflow
+    steps:
+      - name: 'Checkout actions'
+        uses: actions/checkout@v2
+
+      - name: 'Test render-task-definition workflow'
+        uses: ./.github/actions/test-render-task-definition
+        with:
+          aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
+          ref: ${{ github.sha }}

--- a/.github/workflows/test-render-task-definition.yml
+++ b/.github/workflows/test-render-task-definition.yml
@@ -25,7 +25,6 @@ jobs:
       data: .github/actions/test-render-task-definition/data.yml
       customize: .github/actions/test-render-task-definition/customize.py
       environment: TAG=${{ github.sha }}
-      role-name: github-actions-tests
     secrets:
       aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
 


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

We would like a reusable workflow for updating task definitions.  Might as well add the ability to tag it while we are at it.

## Solution

<!-- How does this change fix the problem? -->

Adds an action to tag an ecs resource.

## Notes

<!-- Additional notes here -->

This will be used in the register-task-definition workflow.

