### PR TITLE
Adds action for tagging ecs resources

### DIFF
--- a/.github/actions/test-tag-ecs-resource/action.yml
+++ b/.github/actions/test-tag-ecs-resource/action.yml
@@ -31,6 +31,7 @@ runs:
         role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/github-actions-tests
 
     - name: 'Rewrite task definition file'
+      shell: bash
       run: sed -i.bak 's/{{ tag }}/${{ github.sha }}/g' '${{ github.action_path }}/task-definition.yml'
 
     - name: 'Publish a new revision of the task definition'

--- a/.github/actions/test-tag-ecs-resource/action.yml
+++ b/.github/actions/test-tag-ecs-resource/action.yml
@@ -14,9 +14,9 @@ runs:
     - name: 'Setup brew'
       uses: Homebrew/actions/setup-homebrew@master
 
-    - name: 'Install BATS and jq'
+    - name: 'Install BATS'
       shell: bash
-      run: brew install bats-core jq
+      run: brew install bats-core
 
     - name: 'Checkout'
       uses: actions/checkout@v2

--- a/.github/actions/test-tag-ecs-resource/action.yml
+++ b/.github/actions/test-tag-ecs-resource/action.yml
@@ -32,7 +32,9 @@ runs:
 
     - name: 'Rewrite task definition file'
       shell: bash
-      run: sed -i.bak 's/{{ tag }}/${{ github.sha }}/g' '${{ github.action_path }}/task-definition.yml'
+      run: |
+        sed -i.bak 's/{{ tag }}/${{ github.sha }}/g' '${{ github.action_path }}/task-definition.yml'
+        sed -i.bak 's/{{ account_id }}/${{ inputs.aws-account-id }}/g' '${{ github.action_path }}/task-definition.yml'
 
     - name: 'Publish a new revision of the task definition'
       id: new-revision

--- a/.github/actions/test-tag-ecs-resource/action.yml
+++ b/.github/actions/test-tag-ecs-resource/action.yml
@@ -1,0 +1,55 @@
+---
+
+name: 'Test tag-ecs-resource action'
+description: 'Runs validation against the tag-ecs-resource action'
+
+inputs:
+  aws-account-id:
+    description: 'The AWS Account id'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Setup brew'
+      uses: Homebrew/actions/setup-brew@v2
+
+    - name: 'Install BATS and jq'
+      shell: bash
+      run: brew install bats-core jq
+
+    - name: 'Checkout'
+      uses: actions/checkout@v2
+
+    - name: 'Use local actions'
+      uses: ./.github/actions/use-local-actions
+
+    - name: 'Configure AWS Credentials'
+      uses: aws-actions/configure-aws-credentials@v1-node16
+      with:
+        aws-region: 'us-east-1'
+        role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/github-actions-tests
+
+    - name: 'Rewrite task definition file'
+      run: sed -i.bak 's/{{ tag }}/${{ github.sha }}/g' '${{ github.action_path }}/task-definition.yml'
+
+    - name: 'Publish a new revision of the task definition'
+      id: new-revision
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ github.action_path }}/task-definition.yml
+
+    - name: 'Run tag-ecs-resource action'
+      uses: ./actions/tag-ecs-resource
+      with:
+        resource-arn: ${{ steps.new-revision.outputs.task-definition-arn }}
+        tags: |
+          version=${{ github.sha }}
+          test=yes
+
+    - name: 'Validate'
+      shell: bash
+      run: bats -r ${{ github.action_path }}/tag-ecs-resource.bats
+      env:
+        VERSION: ${{ github.sha }}
+        RESOURCE_ARN:  ${{ steps.new-revision.outputs.task-definition-arn }}

--- a/.github/actions/test-tag-ecs-resource/action.yml
+++ b/.github/actions/test-tag-ecs-resource/action.yml
@@ -12,7 +12,7 @@ runs:
   using: 'composite'
   steps:
     - name: 'Setup brew'
-      uses: Homebrew/actions/setup-brew@v2
+      uses: Homebrew/actions/setup-brew@master
 
     - name: 'Install BATS and jq'
       shell: bash

--- a/.github/actions/test-tag-ecs-resource/action.yml
+++ b/.github/actions/test-tag-ecs-resource/action.yml
@@ -19,7 +19,7 @@ runs:
       run: brew install bats-core
 
     - name: 'Checkout'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: 'Use local actions'
       uses: ./.github/actions/use-local-actions

--- a/.github/actions/test-tag-ecs-resource/action.yml
+++ b/.github/actions/test-tag-ecs-resource/action.yml
@@ -12,7 +12,7 @@ runs:
   using: 'composite'
   steps:
     - name: 'Setup brew'
-      uses: Homebrew/actions/setup-brew@master
+      uses: Homebrew/actions/setup-homebrew@master
 
     - name: 'Install BATS and jq'
       shell: bash

--- a/.github/actions/test-tag-ecs-resource/action.yml
+++ b/.github/actions/test-tag-ecs-resource/action.yml
@@ -52,7 +52,7 @@ runs:
 
     - name: 'Validate'
       shell: bash
-      run: bats -r ${{ github.action_path }}/tag-ecs-resource.bats
+      run: bats --verbose-run -r ${{ github.action_path }}/tag-ecs-resource.bats
       env:
         VERSION: ${{ github.sha }}
         RESOURCE_ARN:  ${{ steps.new-revision.outputs.task-definition-arn }}

--- a/.github/actions/test-tag-ecs-resource/tag-ecs-resource.bats
+++ b/.github/actions/test-tag-ecs-resource/tag-ecs-resource.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+function setup() {
+  :
+}
+
+function teardown() {
+  :
+}
+
+@test "it should have tagged the version" {
+  run aws ecs describe-task-definition \
+    --task-definition "$RESOURCE_ARN" \
+    --no-cli-pager \
+    --output text \
+    --query 'tags.version'
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$VERSION" ]
+}

--- a/.github/actions/test-tag-ecs-resource/tag-ecs-resource.bats
+++ b/.github/actions/test-tag-ecs-resource/tag-ecs-resource.bats
@@ -13,7 +13,8 @@ function teardown() {
     --task-definition "$RESOURCE_ARN" \
     --no-cli-pager \
     --output text \
-    --query 'tags.version'
+    --include TAGS \
+    --query 'tags[?key==`version`].value'
 
   [ "$status" -eq 0 ]
   [ "$output" = "$VERSION" ]

--- a/.github/actions/test-tag-ecs-resource/task-definition.yml
+++ b/.github/actions/test-tag-ecs-resource/task-definition.yml
@@ -1,0 +1,30 @@
+---
+
+family: github-actions-tests
+taskRoleArn: arn:aws:iam::1111111111:role/github-actions-tests-task
+executionRoleArn: arn:aws:iam::1111111111:role/github-actions-tests-execution
+networkMode: awsvpc
+cpu: '256'
+memory: '1024'
+containerDefinitions:
+- name: github-actions-tests
+  image: alpine:latest
+  command: [tail, -f, /dev/null]
+  essential: true
+  logConfiguration:
+    logDriver: awslogs
+    options:
+      awslogs-group: github-actions-tests
+      awslogs-region: us-east-1
+      awslogs-stream-prefix: github-actions-tests
+  environment:
+    - name: APPLICATION
+      value: github-actions-tests
+    - name: APP_VERSION
+      value: '{{ tag }}'
+  dockerLabels:
+    application: github-actions-tests
+    version: '{{ tag }}'
+requiresCompatibilities:
+  - EC2
+  - FARGATE

--- a/.github/actions/test-tag-ecs-resource/task-definition.yml
+++ b/.github/actions/test-tag-ecs-resource/task-definition.yml
@@ -1,8 +1,8 @@
 ---
 
 family: github-actions-tests
-taskRoleArn: arn:aws:iam::1111111111:role/github-actions-tests-task
-executionRoleArn: arn:aws:iam::1111111111:role/github-actions-tests-execution
+taskRoleArn: arn:aws:iam::{{ account_id }}:role/github-actions-tests-task
+executionRoleArn: arn:aws:iam::{{ account_id }}:role/github-actions-tests-execution
 networkMode: awsvpc
 cpu: '256'
 memory: '1024'

--- a/.github/workflows/test-tag-ecs-resource.yml
+++ b/.github/workflows/test-tag-ecs-resource.yml
@@ -1,0 +1,30 @@
+---
+
+name: 'Run tag-ecs-resource action'
+
+on:
+  pull_request:
+    paths:
+      - actions/tag-ecs-resource/*
+      - .github/actions/test-tag-ecs-resource/*
+
+permissions:
+  id-token: write
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test-tag-ecs-resource-action:
+    name: 'Uses the tag-ecs-resource action'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout actions'
+        uses: actions/checkout@v3
+
+      - name: 'Test tag-ecs-resource action'
+        uses: ./.github/actions/test-tag-ecs-resource
+        with:
+          aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}

--- a/actions/tag-ecs-resource/action.yml
+++ b/actions/tag-ecs-resource/action.yml
@@ -1,0 +1,28 @@
+---
+
+name: 'Tag ECS resource'
+description: 'Tags an ECS resource'
+
+inputs:
+  resource-arn:
+    description: 'The ARN of the resource to tag'
+    required: true
+
+  tags:
+    description: |
+      Key value pairs to attach to the resource.
+
+      Example:
+        tags: |
+          version=v1
+          owner=carl
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Tag resource'
+      run: ${{ github.action_path }}/tag-resource.sh "${{ inputs.resource-arn }}"
+      shell: bash
+      env:
+        TAGS: ${{ inputs.tags }}

--- a/actions/tag-ecs-resource/tag-resource.bats
+++ b/actions/tag-ecs-resource/tag-resource.bats
@@ -30,13 +30,13 @@ function aws() {
 @test "it should tag the resource" {
   run tag-resource "$RESOURCE_ARN"
 
-  tagset="[{key='Foo',value='bar'},{key='team',value='my-team'},{key='owner',value='anonymous'}]"
-
   cat "$AWS_CMD_FILE"
 
   [ "$status" -eq 0 ]
   [ -f "$AWS_CMD_FILE" ]
-  [ "$(< "$AWS_CMD_FILE")" = "ecs tag-resource --resource my-resource-arn --tags $tagset" ]
+  [[ "$(< "$AWS_CMD_FILE")" =~ "ecs tag-resource --resource my-resource-arn --tags key=Foo,value=bar".* ]]
+  [[ "$(< "$AWS_CMD_FILE")" =~ .*"ecs tag-resource --resource my-resource-arn --tags key=team,value=my-team".* ]]
+  [[ "$(< "$AWS_CMD_FILE")" =~ .*"ecs tag-resource --resource my-resource-arn --tags key=owner,value=anonymous" ]]
 }
 
 @test "it should do nothing with no tags" {

--- a/actions/tag-ecs-resource/tag-resource.bats
+++ b/actions/tag-ecs-resource/tag-resource.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+load tag-resource.sh
+
+function setup() {
+  export AWS_CMD_FILE="$BATS_TEST_TMPDIR/aws.cmd"
+  export -f aws
+
+  export RESOURCE_ARN=my-resource-arn
+  export TAGS='Foo=bar
+team=my-team
+owner=anonymous
+'
+}
+
+function teardown() {
+  rm -f "$AWS_CMD_FILE"
+}
+
+function aws() {
+  echo "$*" >> "$AWS_CMD_FILE"
+}
+
+@test "it should error out if no resource arn is provided" {
+  run tag-resource
+
+  [ "$status" -ne 0 ]
+}
+
+@test "it should tag the resource" {
+  run tag-resource "$RESOURCE_ARN"
+
+  tagset="[{key='Foo',value='bar'},{key='team',value='my-team'},{key='owner',value='anonymous'}]"
+
+  cat "$AWS_CMD_FILE"
+
+  [ "$status" -eq 0 ]
+  [ -f "$AWS_CMD_FILE" ]
+  [ "$(< "$AWS_CMD_FILE")" = "ecs tag-resource --resource my-resource-arn --tags $tagset" ]
+}
+
+@test "it should do nothing with no tags" {
+  export TAGS=''
+
+  run tag-resource "$RESOURCE_ARN"
+
+  [ "$status" -eq 0 ]
+  ! [ -f "$AWS_CMD_FILE" ]
+}

--- a/actions/tag-ecs-resource/tag-resource.sh
+++ b/actions/tag-ecs-resource/tag-resource.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+function tag-resource() {
+  set -eo pipefail
+
+  local resource_arn="${1:-}"
+  [ -n "$resource_arn" ] || {
+    echo "[ERROR] Resource arn not provided" >&2
+    return 1
+  }
+
+  [ -n "${TAGS:-}" ] || {
+    echo "[INFO ] No tags provided" >&2
+    return 0
+  }
+
+  # Split up tags in put them in the format desired
+  #   Input:  key=value
+  #   Output: key=$key,value=$value
+  local tags=''
+  while IFS= read -r tag_var; do
+    # Remove blank space around the string
+    tag_var="$(echo "${tag_var?}" | xargs)"
+    key="${tag_var%=*}"
+    val="${tag_var#*=}"
+
+    [ -n "${tag_var?}" ] || continue
+
+    tags+="{key='""$key""',value='""$val""'},"
+  done <<<"$TAGS"
+  tags="[${tags::-1}]" # pop off the last comma
+
+  aws ecs tag-resource \
+    --resource "$resource_arn" \
+    --tags "$tags"
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  set -u
+
+  tag-resource "${@:-}"
+  exit $?
+fi

--- a/actions/tag-ecs-resource/tag-resource.sh
+++ b/actions/tag-ecs-resource/tag-resource.sh
@@ -27,7 +27,7 @@ function tag-resource() {
 
     tag="key=$key,value=$val"
 
-    echo "[INFO ] Setting the $key tag on resource: $resource_arn" >&2
+    echo "[INFO ] Setting the $key tag" >&2
     aws ecs tag-resource \
       --resource "$resource_arn" \
       --tags "$tag"

--- a/actions/tag-ecs-resource/tag-resource.sh
+++ b/actions/tag-ecs-resource/tag-resource.sh
@@ -17,7 +17,6 @@ function tag-resource() {
   # Split up tags in put them in the format desired
   #   Input:  key=value
   #   Output: key=$key,value=$value
-  local tags=()
   while IFS= read -r tag_var; do
     # Remove blank space around the string
     tag_var="$(echo "${tag_var?}" | xargs)"
@@ -26,14 +25,13 @@ function tag-resource() {
 
     [ -n "${tag_var?}" ] || continue
 
-    tags+=("key=$key,value=$val")
-  done <<<"$TAGS"
+    tag="key=$key,value=$val"
 
-  for tag in "${tags[@]}"; do
+    echo "[INFO ] Setting the $key tag on resource: $resource_arn" >&2
     aws ecs tag-resource \
       --resource "$resource_arn" \
       --tags "$tag"
-  done
+  done <<<"$TAGS"
 }
 
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then

--- a/actions/tag-ecs-resource/tag-resource.sh
+++ b/actions/tag-ecs-resource/tag-resource.sh
@@ -17,7 +17,7 @@ function tag-resource() {
   # Split up tags in put them in the format desired
   #   Input:  key=value
   #   Output: key=$key,value=$value
-  local tags=''
+  local tags=()
   while IFS= read -r tag_var; do
     # Remove blank space around the string
     tag_var="$(echo "${tag_var?}" | xargs)"
@@ -26,13 +26,14 @@ function tag-resource() {
 
     [ -n "${tag_var?}" ] || continue
 
-    tags+="{key='""$key""',value='""$val""'},"
+    tags+=("key=$key,value=$val")
   done <<<"$TAGS"
-  tags="[${tags::-1}]" # pop off the last comma
 
-  aws ecs tag-resource \
-    --resource "$resource_arn" \
-    --tags "$tags"
+  for tag in "${tags[@]}"; do
+    aws ecs tag-resource \
+      --resource "$resource_arn" \
+      --tags "$tag"
+  done
 }
 
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

We would like a reusable workflow for updating task definitions.  Might as well add the ability to tag it while we are at it.

## Solution

<!-- How does this change fix the problem? -->

Adds an action to tag an ecs resource.

## Notes

<!-- Additional notes here -->

This will be used in the register-task-definition workflow.

