### PR TITLE
Adds reusable register task definition workflow

### DIFF
--- a/.github/actions/test-register-task-definition/action.yml
+++ b/.github/actions/test-register-task-definition/action.yml
@@ -38,4 +38,4 @@ runs:
       run: bats --verbose-run -r ${{ github.action_path }}/register-task-definition.bats
       env:
         VERSION: ${{ github.sha }}
-        TASK_DEFINITION_ARN:  ${{ inputs.task-definition-arn }}
+        TASK_DEFINITION_ARN: ${{ inputs.task-definition-arn }}

--- a/.github/actions/test-register-task-definition/action.yml
+++ b/.github/actions/test-register-task-definition/action.yml
@@ -1,9 +1,12 @@
 ---
 
-name: 'Test tag-ecs-resource action'
-description: 'Runs validation against the tag-ecs-resource action'
+name: 'Test register-task-definition action'
+description: 'Runs validation against the register-task-definition action'
 
 inputs:
+  task-definition-arn:
+    description: 'The ARN of the task definition to test against'
+    required: true
   aws-account-id:
     description: 'The AWS Account id'
     required: true
@@ -30,29 +33,9 @@ runs:
         aws-region: 'us-east-1'
         role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/github-actions-tests
 
-    - name: 'Rewrite task definition file'
-      shell: bash
-      run: |
-        sed -i.bak 's/{{ tag }}/${{ github.sha }}/g' '${{ github.action_path }}/task-definition.yml'
-        sed -i.bak 's/{{ account_id }}/${{ inputs.aws-account-id }}/g' '${{ github.action_path }}/task-definition.yml'
-
-    - name: 'Publish a new revision of the task definition'
-      id: new-revision
-      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-      with:
-        task-definition: ${{ github.action_path }}/task-definition.yml
-
-    - name: 'Run tag-ecs-resource action'
-      uses: ./actions/tag-ecs-resource
-      with:
-        resource-arn: ${{ steps.new-revision.outputs.task-definition-arn }}
-        tags: |
-          version=${{ github.sha }}
-          test=yes
-
     - name: 'Validate'
       shell: bash
-      run: bats --verbose-run -r ${{ github.action_path }}/tag-ecs-resource.bats
+      run: bats --verbose-run -r ${{ github.action_path }}/register-task-definition.bats
       env:
         VERSION: ${{ github.sha }}
-        RESOURCE_ARN:  ${{ steps.new-revision.outputs.task-definition-arn }}
+        TASK_DEFINITION_ARN:  ${{ inputs.task-definition-arn }}

--- a/.github/actions/test-register-task-definition/action.yml
+++ b/.github/actions/test-register-task-definition/action.yml
@@ -1,0 +1,58 @@
+---
+
+name: 'Test tag-ecs-resource action'
+description: 'Runs validation against the tag-ecs-resource action'
+
+inputs:
+  aws-account-id:
+    description: 'The AWS Account id'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Setup brew'
+      uses: Homebrew/actions/setup-homebrew@master
+
+    - name: 'Install BATS'
+      shell: bash
+      run: brew install bats-core
+
+    - name: 'Checkout'
+      uses: actions/checkout@v3
+
+    - name: 'Use local actions'
+      uses: ./.github/actions/use-local-actions
+
+    - name: 'Configure AWS Credentials'
+      uses: aws-actions/configure-aws-credentials@v1-node16
+      with:
+        aws-region: 'us-east-1'
+        role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/github-actions-tests
+
+    - name: 'Rewrite task definition file'
+      shell: bash
+      run: |
+        sed -i.bak 's/{{ tag }}/${{ github.sha }}/g' '${{ github.action_path }}/task-definition.yml'
+        sed -i.bak 's/{{ account_id }}/${{ inputs.aws-account-id }}/g' '${{ github.action_path }}/task-definition.yml'
+
+    - name: 'Publish a new revision of the task definition'
+      id: new-revision
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ github.action_path }}/task-definition.yml
+
+    - name: 'Run tag-ecs-resource action'
+      uses: ./actions/tag-ecs-resource
+      with:
+        resource-arn: ${{ steps.new-revision.outputs.task-definition-arn }}
+        tags: |
+          version=${{ github.sha }}
+          test=yes
+
+    - name: 'Validate'
+      shell: bash
+      run: bats --verbose-run -r ${{ github.action_path }}/tag-ecs-resource.bats
+      env:
+        VERSION: ${{ github.sha }}
+        RESOURCE_ARN:  ${{ steps.new-revision.outputs.task-definition-arn }}

--- a/.github/actions/test-register-task-definition/register-task-definition.bats
+++ b/.github/actions/test-register-task-definition/register-task-definition.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 function setup() {
-  :
+  export FAMILY_REVISION="${TASK_DEFINITION_ARN#*task-definition/}"
 }
 
 function teardown() {
@@ -9,9 +9,24 @@ function teardown() {
 }
 
 @test "it should have updated the task definition" {
-  run
+  run aws ecs describe-task-definition \
+    --task-definition "$FAMILY_REVISION" \
+    --no-cli-pager \
+    --output text \
+    --query 'taskDefinition.containerDefinitions[0].dockerLabels.version'
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$VERSION" ]
 }
 
-@test "it should" {
-    run
+@test "it should have tagged the task definition" {
+  run aws ecs describe-task-definition \
+    --task-definition "$FAMILY_REVISION" \
+    --no-cli-pager \
+    --output text \
+    --include TAGS \
+    --query 'tags[?key==`version`].value'
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$VERSION" ]
 }

--- a/.github/actions/test-register-task-definition/register-task-definition.bats
+++ b/.github/actions/test-register-task-definition/register-task-definition.bats
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+
+function setup() {
+  :
+}
+
+function teardown() {
+  :
+}
+
+@test "it should have updated the task definition" {
+  run
+}
+
+@test "it should" {
+    run
+}

--- a/.github/actions/test-register-task-definition/task-definition.yml
+++ b/.github/actions/test-register-task-definition/task-definition.yml
@@ -1,0 +1,30 @@
+---
+
+family: github-actions-tests
+taskRoleArn: arn:aws:iam::{{ account_id }}:role/github-actions-tests-task
+executionRoleArn: arn:aws:iam::{{ account_id }}:role/github-actions-tests-execution
+networkMode: awsvpc
+cpu: '256'
+memory: '1024'
+containerDefinitions:
+- name: github-actions-tests
+  image: alpine:latest
+  command: [tail, -f, /dev/null]
+  essential: true
+  logConfiguration:
+    logDriver: awslogs
+    options:
+      awslogs-group: github-actions-tests
+      awslogs-region: us-east-1
+      awslogs-stream-prefix: github-actions-tests
+  environment:
+    - name: APPLICATION
+      value: github-actions-tests
+    - name: APP_VERSION
+      value: '{{ tag }}'
+  dockerLabels:
+    application: github-actions-tests
+    version: '{{ tag }}'
+requiresCompatibilities:
+  - EC2
+  - FARGATE

--- a/.github/workflows/register-task-definition.yml
+++ b/.github/workflows/register-task-definition.yml
@@ -1,0 +1,131 @@
+---
+
+name: 'Register task definition'
+
+on:
+  workflow_call:
+    inputs:
+      aws-region:
+        description: 'The aws region where resources live'
+        type: string
+        default: us-east-1
+
+      role-name:
+        description: 'The name of the IAM role allowed to upload the task definition'
+        type: string
+        required: true
+
+      # begin aws-actions/amazon-ecs-deploy-task-definition
+      task-definition:
+        description: 'The path to the ECS task definition file to register'
+        type: string
+        required: false
+        default: task-definition.yml
+      service:
+        description: 'The name of the ECS service to deploy to. The action will only register the task definition if no service is given.'
+        type: string
+        required: false
+      cluster:
+        description: "The name of the ECS service's cluster.  Will default to the 'default' cluster"
+        type: string
+        required: false
+      wait-for-service-stability:
+        description: 'Whether to wait for the ECS service to reach stable state after deploying the new task definition. Valid value is "true". Will default to not waiting.'
+        type: boolean
+        required: false
+      wait-for-minutes:
+        description: 'How long to wait for the ECS service to reach stable state, in minutes (default: 30 minutes, max: 6 hours). For CodeDeploy deployments, any wait time configured in the CodeDeploy deployment group will be added to this value.'
+        type: number
+        required: false
+      codedeploy-appspec:
+        description: "The path to the AWS CodeDeploy AppSpec file, if the ECS service uses the CODE_DEPLOY deployment controller. Will default to 'appspec.yaml'."
+        type: string
+        required: false
+      codedeploy-application:
+        description: "The name of the AWS CodeDeploy application, if the ECS service uses the CODE_DEPLOY deployment controller. Will default to 'AppECS-{cluster}-{service}'."
+        type: string
+        required: false
+      codedeploy-deployment-group:
+        description: "The name of the AWS CodeDeploy deployment group, if the ECS service uses the CODE_DEPLOY deployment controller. Will default to 'DgpECS-{cluster}-{service}'."
+        type: string
+        required: false
+      codedeploy-deployment-description:
+        description: "A description of the deployment, if the ECS service uses the CODE_DEPLOY deployment controller."
+        type: string
+        required: false
+      force-new-deployment:
+        description: 'Whether to force a new deployment of the service. Valid value is "true". Will default to not force a new deployment.'
+        type: boolean
+        required: false
+      # end aws-actions/amazon-ecs-deploy-task-definition
+
+      task-definition-tags:
+        type: string
+        required: false
+      service-tags:
+        description: ''
+        type: string
+        required: false
+
+    secrets:
+      aws-account-id:
+        description: 'The AWS account id that the ecr repository lives under'
+        required: true
+
+permissions:
+  contents: read  # default
+  id-token: write # aws auth
+
+env:
+  DEPLOY_IAM_ROLE: arn:aws:iam::${{ secrets.aws-account-id }}:role/${{ inputs.role-name }}
+  ECS_SERVICE_ARN: arn:aws:ecs:${{ inputs.aws-region }}:${{ secrets.aws-account-id }}:service/${{ inputs.service }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  register-task-definition:
+    name: 'Register task definition'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Download task-definition'
+        uses: actions/download-artifact@v3
+        with:
+          name: task-definition
+
+      - name: 'Configure AWS Credentials'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ inputs.aws-region }}
+          role-to-assume: ${{ env.DEPLOY_IAM_ROLE }}
+
+      - name: 'Register task definition'
+        id: register
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ inputs.task-definition }}
+          service: ${{ inputs.service }}
+          cluster: ${{ inputs.cluster }}
+          wait-for-service-stability: ${{ inputs.wait-for-service-stability }}
+          wait-for-minutes: ${{ inputs.wait-for-minutes }}
+          codedeploy-appspec: ${{ inputs.codedeploy-appspec }}
+          codedeploy-application: ${{ inputs.codedeploy-application }}
+          codedeploy-deployment-group: ${{ inputs.codedeploy-deployment-group }}
+          codedeploy-deployment-description: ${{ inputs.codedeploy-deployment-description }}
+          force-new-deployment: ${{ inputs.force-new-deployment }}
+
+      - name: 'Tag the task definition'
+        # TODO: Tag this!!
+        uses: shopsmart/github-actions/actions/tag-ecs-resource@feature/tag-ecs-resource
+        with:
+          resource-arn: ${{ steps.register.outputs.task-definition-arn }}
+          tags: ${{ inputs.task-definition-tags }}
+
+      - name: 'Tag the ECS Service'
+        if: inputs.service != ''
+        # TODO: Tag this!!
+        uses: shopsmart/github-actions/actions/tag-ecs-resource@feature/tag-ecs-resource
+        with:
+          resource-arn: ${{ env.ECS_SERVICE_ARN }}
+          tags: ${{ inputs.service-tags }}

--- a/.github/workflows/register-task-definition.yml
+++ b/.github/workflows/register-task-definition.yml
@@ -72,6 +72,11 @@ on:
         description: 'The AWS account id that the ecr repository lives under'
         required: true
 
+    outputs:
+      task-definition-arn:
+        description: 'The ARN of the task definition just published'
+        value: ${{ steps.register.outputs.task-definition-arn }}
+
 permissions:
   contents: read  # default
   id-token: write # aws auth

--- a/.github/workflows/register-task-definition.yml
+++ b/.github/workflows/register-task-definition.yml
@@ -95,7 +95,7 @@ jobs:
           name: task-definition
 
       - name: 'Configure AWS Credentials'
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: ${{ inputs.aws-region }}
           role-to-assume: ${{ env.DEPLOY_IAM_ROLE }}

--- a/.github/workflows/register-task-definition.yml
+++ b/.github/workflows/register-task-definition.yml
@@ -139,6 +139,6 @@ jobs:
 
       - name: 'Get revision number'
         id: revision
-        run: echo "revision=${TASK_DEFINITION_ARN##*:}" >> $GITHUB_OUTPUT
+        run: echo "revision-number=${TASK_DEFINITION_ARN##*:}" >> $GITHUB_OUTPUT
         env:
           TASK_DEFINITION_ARN: ${{ steps.register.outputs.task-definition-arn }}

--- a/.github/workflows/register-task-definition.yml
+++ b/.github/workflows/register-task-definition.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: 'Register task definition'
         id: register
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:
           task-definition: ${{ inputs.task-definition }}
           service: ${{ inputs.service }}

--- a/.github/workflows/register-task-definition.yml
+++ b/.github/workflows/register-task-definition.yml
@@ -75,7 +75,7 @@ on:
     outputs:
       task-definition-arn:
         description: 'The ARN of the task definition just published'
-        value: ${{ steps.register.outputs.task-definition-arn }}
+        value: ${{ jobs.register-task-definition.outputs.task-definition-arn }}
 
 permissions:
   contents: read  # default
@@ -93,6 +93,8 @@ jobs:
   register-task-definition:
     name: 'Register task definition'
     runs-on: ubuntu-latest
+    outputs:
+      task-definition-arn: ${{ steps.register.outputs.task-definition-arn }}
     steps:
       - name: 'Download task-definition'
         uses: actions/download-artifact@v3

--- a/.github/workflows/register-task-definition.yml
+++ b/.github/workflows/register-task-definition.yml
@@ -73,9 +73,9 @@ on:
         required: true
 
     outputs:
-      task-definition-arn:
-        description: 'The ARN of the task definition just published'
-        value: ${{ jobs.register-task-definition.outputs.task-definition-arn }}
+      revision-number:
+        description: 'The revision number of the task definition just published'
+        value: ${{ jobs.register-task-definition.outputs.revision-number }}
 
 permissions:
   contents: read  # default
@@ -94,7 +94,7 @@ jobs:
     name: 'Register task definition'
     runs-on: ubuntu-latest
     outputs:
-      task-definition-arn: ${{ steps.register.outputs.task-definition-arn }}
+      revision-number: ${{ steps.revision.outputs.revision-number }}
     steps:
       - name: 'Download task-definition'
         uses: actions/download-artifact@v3
@@ -136,3 +136,9 @@ jobs:
         with:
           resource-arn: ${{ env.ECS_SERVICE_ARN }}
           tags: ${{ inputs.service-tags }}
+
+      - name: 'Get revision number'
+        id: revision
+        run: echo "revision=${TASK_DEFINITION_ARN##*:}" >> $GITHUB_OUTPUT
+        env:
+          TASK_DEFINITION_ARN: ${{ steps.register.outputs.task-definition-arn }}

--- a/.github/workflows/register-task-definition.yml
+++ b/.github/workflows/register-task-definition.yml
@@ -123,16 +123,14 @@ jobs:
           force-new-deployment: ${{ inputs.force-new-deployment }}
 
       - name: 'Tag the task definition'
-        # TODO: Tag this!!
-        uses: shopsmart/github-actions/actions/tag-ecs-resource@feature/tag-ecs-resource-rebased
+        uses: shopsmart/github-actions/actions/tag-ecs-resource@v2
         with:
           resource-arn: ${{ steps.register.outputs.task-definition-arn }}
           tags: ${{ inputs.task-definition-tags }}
 
       - name: 'Tag the ECS Service'
         if: inputs.service != ''
-        # TODO: Tag this!!
-        uses: shopsmart/github-actions/actions/tag-ecs-resource@feature/tag-ecs-resource-rebased
+        uses: shopsmart/github-actions/actions/tag-ecs-resource@v2
         with:
           resource-arn: ${{ env.ECS_SERVICE_ARN }}
           tags: ${{ inputs.service-tags }}

--- a/.github/workflows/register-task-definition.yml
+++ b/.github/workflows/register-task-definition.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: 'Tag the task definition'
         # TODO: Tag this!!
-        uses: shopsmart/github-actions/actions/tag-ecs-resource@feature/tag-ecs-resource
+        uses: shopsmart/github-actions/actions/tag-ecs-resource@feature/tag-ecs-resource-rebased
         with:
           resource-arn: ${{ steps.register.outputs.task-definition-arn }}
           tags: ${{ inputs.task-definition-tags }}
@@ -125,7 +125,7 @@ jobs:
       - name: 'Tag the ECS Service'
         if: inputs.service != ''
         # TODO: Tag this!!
-        uses: shopsmart/github-actions/actions/tag-ecs-resource@feature/tag-ecs-resource
+        uses: shopsmart/github-actions/actions/tag-ecs-resource@feature/tag-ecs-resource-rebased
         with:
           resource-arn: ${{ env.ECS_SERVICE_ARN }}
           tags: ${{ inputs.service-tags }}

--- a/.github/workflows/test-register-task-definition.yml
+++ b/.github/workflows/test-register-task-definition.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: task-definition
-          paths: .github/actions/test-register-task-definition/task-definition.yml
+          path: .github/actions/test-register-task-definition/task-definition.yml
 
       - name: 'Error out'
         run: exit 1

--- a/.github/workflows/test-register-task-definition.yml
+++ b/.github/workflows/test-register-task-definition.yml
@@ -16,6 +16,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  AWS_REGION: us-east-1
+
 jobs:
   upload-task-definition:
     name: 'Upload task definition'
@@ -43,7 +46,7 @@ jobs:
     needs: upload-task-definition
     with:
       role-name: github-actions-tests
-      aws-region: 'us-east-1'
+      aws-region: ${{ env.AWS_REGION }}
     secrets:
       aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
 
@@ -51,6 +54,8 @@ jobs:
     name: 'Uses the register-task-definition workflow'
     runs-on: ubuntu-latest
     needs: run-register-task-definition-workflow
+    env:
+      TASK_DEFINITION_ARN: arn:aws:ecs:${{ env.AWS_REGION }}:${{ secrets.AWS_ACCOUNT_ID }}:task-definition/github-actions-tests:${{ needs.run-register-task-definition-workflow.outputs.revision-number }}
     steps:
       - name: 'Checkout actions'
         uses: actions/checkout@v2
@@ -58,5 +63,5 @@ jobs:
       - name: 'Test register-task-definition workflow'
         uses: ./.github/actions/test-register-task-definition
         with:
-          task-definition-arn: ${{ needs.run-register-task-definition-workflow.outputs.task-definition-arn }}
+          task-definition-arn: ${{ env.TASK_DEFINITION_ARN }}
           aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}

--- a/.github/workflows/test-register-task-definition.yml
+++ b/.github/workflows/test-register-task-definition.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash
         run: |
           sed -i.bak 's/{{ tag }}/${{ github.sha }}/g' '${{ env.ACTION_PATH }}/task-definition.yml'
-          sed -i.bak 's/{{ account_id }}/${{ inputs.aws-account-id }}/g' '${{ env.ACTION_PATH }}/task-definition.yml'
+          sed -i.bak 's/{{ account_id }}/${{ secrets.AWS_ACCOUNT_ID }}/g' '${{ env.ACTION_PATH }}/task-definition.yml'
 
       - name: 'Upload task definition file'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/test-register-task-definition.yml
+++ b/.github/workflows/test-register-task-definition.yml
@@ -44,6 +44,7 @@ jobs:
     with:
       role-name: github-actions-tests
       aws-region: 'us-east-1'
+      task-definition-tags: version=${{ github.sha }}
     secrets:
       aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
 

--- a/.github/workflows/test-register-task-definition.yml
+++ b/.github/workflows/test-register-task-definition.yml
@@ -35,6 +35,9 @@ jobs:
           name: task-definition
           paths: .github/actions/test-register-task-definition/task-definition.yml
 
+      - name: 'Error out'
+        run: exit 1
+
   run-register-task-definition-workflow:
     uses: ./.github/workflows/register-task-definition.yml
     with:

--- a/.github/workflows/test-register-task-definition.yml
+++ b/.github/workflows/test-register-task-definition.yml
@@ -40,6 +40,7 @@ jobs:
 
   run-register-task-definition-workflow:
     uses: ./.github/workflows/register-task-definition.yml
+    needs: upload-task-definition
     with:
       role-name: github-actions-tests
       aws-region: 'us-east-1'

--- a/.github/workflows/test-register-task-definition.yml
+++ b/.github/workflows/test-register-task-definition.yml
@@ -58,5 +58,5 @@ jobs:
       - name: 'Test register-task-definition workflow'
         uses: ./.github/actions/test-register-task-definition
         with:
+          task-definition-arn: ${{ needs.run-register-task-definition-workflow.outputs.task-definition-arn }}
           aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
-          ref: ${{ github.sha }}

--- a/.github/workflows/test-register-task-definition.yml
+++ b/.github/workflows/test-register-task-definition.yml
@@ -33,7 +33,7 @@ jobs:
           sed -i.bak 's/{{ account_id }}/${{ secrets.AWS_ACCOUNT_ID }}/g' '${{ env.ACTION_PATH }}/task-definition.yml'
 
       - name: 'Upload task definition file'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: task-definition
           path: ${{ env.ACTION_PATH }}/task-definition.yml

--- a/.github/workflows/test-register-task-definition.yml
+++ b/.github/workflows/test-register-task-definition.yml
@@ -16,9 +16,6 @@ defaults:
   run:
     shell: bash
 
-env:
-  AWS_REGION: us-east-1
-
 jobs:
   upload-task-definition:
     name: 'Upload task definition'
@@ -46,7 +43,7 @@ jobs:
     needs: upload-task-definition
     with:
       role-name: github-actions-tests
-      aws-region: ${{ env.AWS_REGION }}
+      aws-region: 'us-east-1'
     secrets:
       aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
 
@@ -55,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: run-register-task-definition-workflow
     env:
-      TASK_DEFINITION_ARN: arn:aws:ecs:${{ env.AWS_REGION }}:${{ secrets.AWS_ACCOUNT_ID }}:task-definition/github-actions-tests:${{ needs.run-register-task-definition-workflow.outputs.revision-number }}
+      TASK_DEFINITION_ARN: arn:aws:ecs:us-east-1:${{ secrets.AWS_ACCOUNT_ID }}:task-definition/github-actions-tests:${{ needs.run-register-task-definition-workflow.outputs.revision-number }}
     steps:
       - name: 'Checkout actions'
         uses: actions/checkout@v2

--- a/.github/workflows/test-register-task-definition.yml
+++ b/.github/workflows/test-register-task-definition.yml
@@ -24,19 +24,17 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@v3
 
-      # TODO - How do we do this without the task definition file
-      # being exposed with an account id in it?
-      # - name: 'Create task definition file'
-      # Normally we would render the task definition with the account id
+      - name: 'Rewrite task definition file'
+        shell: bash
+        run: |
+          sed -i.bak 's/{{ tag }}/${{ github.sha }}/g' '${{ github.action_path }}/task-definition.yml'
+          sed -i.bak 's/{{ account_id }}/${{ inputs.aws-account-id }}/g' '${{ github.action_path }}/task-definition.yml'
 
       - name: 'Upload task definition file'
         uses: actions/upload-artifact@v2
         with:
           name: task-definition
-          path: .github/actions/test-register-task-definition/task-definition.yml
-
-      - name: 'Error out'
-        run: exit 1
+          path: ${{ github.action_path }}/task-definition.yml
 
   run-register-task-definition-workflow:
     uses: ./.github/workflows/register-task-definition.yml

--- a/.github/workflows/test-register-task-definition.yml
+++ b/.github/workflows/test-register-task-definition.yml
@@ -1,0 +1,58 @@
+---
+
+name: 'Run register-task-definition workflow'
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/register-task-definition.yml
+      - .github/actions/test-register-task-definition/*
+
+permissions:
+  id-token: write # aws auth
+  contents: write # publish release assets
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  upload-task-definition:
+    name: 'Upload task definition'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+
+      # TODO - How do we do this without the task definition file
+      # being exposed with an account id in it?
+      # - name: 'Create task definition file'
+      # Normally we would render the task definition with the account id
+
+      - name: 'Upload task definition file'
+        uses: actions/upload-artifact@v2
+        with:
+          name: task-definition
+          paths: .github/actions/test-register-task-definition/task-definition.yml
+
+  run-register-task-definition-workflow:
+    uses: ./.github/workflows/register-task-definition.yml
+    with:
+      role-name: github-actions-tests
+      aws-region: 'us-east-1'
+    secrets:
+      aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
+
+  test-register-task-definition-workflow:
+    name: 'Uses the register-task-definition workflow'
+    runs-on: ubuntu-latest
+    needs: run-register-task-definition-workflow
+    steps:
+      - name: 'Checkout actions'
+        uses: actions/checkout@v2
+
+      - name: 'Test register-task-definition workflow'
+        uses: ./.github/actions/test-register-task-definition
+        with:
+          aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
+          ref: ${{ github.sha }}

--- a/.github/workflows/test-register-task-definition.yml
+++ b/.github/workflows/test-register-task-definition.yml
@@ -20,6 +20,8 @@ jobs:
   upload-task-definition:
     name: 'Upload task definition'
     runs-on: ubuntu-latest
+    env:
+      ACTION_PATH: .github/actions/test-register-task-definition
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3
@@ -27,14 +29,14 @@ jobs:
       - name: 'Rewrite task definition file'
         shell: bash
         run: |
-          sed -i.bak 's/{{ tag }}/${{ github.sha }}/g' '${{ github.action_path }}/task-definition.yml'
-          sed -i.bak 's/{{ account_id }}/${{ inputs.aws-account-id }}/g' '${{ github.action_path }}/task-definition.yml'
+          sed -i.bak 's/{{ tag }}/${{ github.sha }}/g' '${{ env.ACTION_PATH }}/task-definition.yml'
+          sed -i.bak 's/{{ account_id }}/${{ inputs.aws-account-id }}/g' '${{ env.ACTION_PATH }}/task-definition.yml'
 
       - name: 'Upload task definition file'
         uses: actions/upload-artifact@v2
         with:
           name: task-definition
-          path: ${{ github.action_path }}/task-definition.yml
+          path: ${{ env.ACTION_PATH }}/task-definition.yml
 
   run-register-task-definition-workflow:
     uses: ./.github/workflows/register-task-definition.yml


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

We would like to easily register task definitions from a reusable workflow.

## Solution

<!-- How does this change fix the problem? -->

Adds a workflow to register task definitions.

## Notes

<!-- Additional notes here -->

~The test is currently incomplete because uploading the task definition file exposes the account id.  We prepared for this by creating a separate account for public, but I would prefer still not to expose it.~
*UPDATE*: It looks like the artifacts are not publicly accessible meaning that we can upload it without worrying about exposing the account id!!  🙌 

Requires #20.