### PR TITLE
Adds cluster to ECS service ARN when not empty

### DIFF
--- a/.github/workflows/register-task-definition.yml
+++ b/.github/workflows/register-task-definition.yml
@@ -83,7 +83,7 @@ permissions:
 
 env:
   DEPLOY_IAM_ROLE: arn:aws:iam::${{ secrets.aws-account-id }}:role/${{ inputs.role-name }}
-  ECS_SERVICE_ARN: arn:aws:ecs:${{ inputs.aws-region }}:${{ secrets.aws-account-id }}:service/${{ inputs.service }}
+  ECS_SERVICE_ARN: arn:aws:ecs:${{ inputs.aws-region }}:${{ secrets.aws-account-id }}:service/${{ inputs.cluster && format('{0}/', inputs.cluster) }}${{ inputs.service }}
 
 defaults:
   run:


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

The cluster is part of the service arn when it is not 'default'/empty

## Solution

<!-- How does this change fix the problem? -->

Adds the cluster to the arn if provided.

## Notes

<!-- Additional notes here -->

Do NOT pass cluster: 'default'.
