### PR TITLE
Allows environment to be specified in register-task-definition.yml

### DIFF
--- a/.github/workflows/register-task-definition.yml
+++ b/.github/workflows/register-task-definition.yml
@@ -5,6 +5,11 @@ name: 'Register task definition'
 on:
   workflow_call:
     inputs:
+      environment:
+        description: 'If provided, the environment to deploy to.  This will use github environments for the job.'
+        type: string
+        required: false
+
       aws-region:
         description: 'The aws region where resources live'
         type: string
@@ -93,6 +98,7 @@ jobs:
   register-task-definition:
     name: 'Register task definition'
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     outputs:
       revision-number: ${{ steps.revision.outputs.revision-number }}
     steps:


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

We would like to specify the Github environment we are deploying to.

## Solution

<!-- How does this change fix the problem? -->

Passes environment input to the register-task-definition job.

## Notes

<!-- Additional notes here -->
