### PR TITLE
Allows the task-definition artifact to be renamed

### DIFF
--- a/.github/actions/test-render-task-definition/action.yml
+++ b/.github/actions/test-render-task-definition/action.yml
@@ -1,7 +1,7 @@
 ---
 
-name: 'Test build-ecr-image workflow'
-description: 'Runs validation against the build-ecr-image workflow'
+name: 'Test render-task-definition workflow'
+description: 'Runs validation against the render-task-definition workflow'
 
 inputs:
   ref:
@@ -24,7 +24,7 @@ runs:
     - name: 'Download task-definition'
       uses: actions/download-artifact@v2
       with:
-        name: task-definition
+        name: task-definition-renamed
 
     - name: 'Validate'
       shell: bash

--- a/.github/workflows/register-task-definition.yml
+++ b/.github/workflows/register-task-definition.yml
@@ -65,12 +65,18 @@ on:
       # end aws-actions/amazon-ecs-deploy-task-definition
 
       task-definition-tags:
+        description: 'Tags to add to the task definition. Format is key=value separated by new lines'
         type: string
         required: false
       service-tags:
-        description: ''
+        description: 'Tags to add to the ECS service. Format is key=value separated by new lines'
         type: string
         required: false
+
+      artifact-name:
+        description: 'The name of the artifact to download'
+        type: string
+        default: task-definition
 
     secrets:
       aws-account-id:
@@ -105,7 +111,7 @@ jobs:
       - name: 'Download task-definition'
         uses: actions/download-artifact@v3
         with:
-          name: task-definition
+          name: ${{ inputs.artifact-name }}
 
       - name: 'Configure AWS Credentials'
         uses: aws-actions/configure-aws-credentials@v1-node16

--- a/.github/workflows/render-task-definition.yml
+++ b/.github/workflows/render-task-definition.yml
@@ -68,6 +68,11 @@ on:
         default: 'task-definition.yml' # Changed default
       # end shopsmart/render-j2-action inputs
 
+      artifact-name:
+        description: 'The name of the artifact to upload'
+        type: string
+        default: task-definition
+
     secrets:
       aws-account-id:
         description: 'The AWS account id that the ecr repository lives under'
@@ -107,5 +112,5 @@ jobs:
       - name: 'Upload task definition'
         uses: actions/upload-artifact@v3
         with:
-          name: task-definition
+          name: ${{ inputs.artifact-name }}
           path: ${{ inputs.output }}

--- a/.github/workflows/test-register-task-definition.yml
+++ b/.github/workflows/test-register-task-definition.yml
@@ -35,13 +35,14 @@ jobs:
       - name: 'Upload task definition file'
         uses: actions/upload-artifact@v3
         with:
-          name: task-definition
+          name: task-definition-renamed
           path: ${{ env.ACTION_PATH }}/task-definition.yml
 
   run-register-task-definition-workflow:
     uses: ./.github/workflows/register-task-definition.yml
     needs: upload-task-definition
     with:
+      artifact-name: task-definition-renamed
       role-name: github-actions-tests
       aws-region: 'us-east-1'
       task-definition-tags: version=${{ github.sha }}

--- a/.github/workflows/test-render-task-definition.yml
+++ b/.github/workflows/test-render-task-definition.yml
@@ -21,6 +21,7 @@ jobs:
   run-render-task-definition-workflow:
     uses: ./.github/workflows/render-task-definition.yml
     with:
+      artifact-name: task-definition-renamed
       template: .github/actions/test-render-task-definition/task-definition.yml.j2
       data: .github/actions/test-render-task-definition/data.yml
       customize: .github/actions/test-render-task-definition/customize.py


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

We would like to be able to render two different task definitions.

## Solution

<!-- How does this change fix the problem? -->

Allows the artifact name to be configured to avoid overwriting the existing task-definition when running multiple times.

## Notes

<!-- Additional notes here -->
