### PR TITLE
Bumps render-j2-action to v2

### DIFF
--- a/.github/workflows/render-task-definition.yml
+++ b/.github/workflows/render-task-definition.yml
@@ -98,7 +98,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: 'Render task definition'
-        uses: shopsmart/render-j2-action@feature/multiple-data-files
+        uses: shopsmart/render-j2-action@v2
         with:
           template: ${{ inputs.template }}
           data: ${{ inputs.data }}

--- a/.github/workflows/render-task-definition.yml
+++ b/.github/workflows/render-task-definition.yml
@@ -93,7 +93,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: 'Render task definition'
-        uses: shopsmart/render-j2-action@v1
+        uses: shopsmart/render-j2-action@v2
         with:
           template: ${{ inputs.template }}
           data: ${{ inputs.data }}

--- a/.github/workflows/render-task-definition.yml
+++ b/.github/workflows/render-task-definition.yml
@@ -98,7 +98,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: 'Render task definition'
-        uses: shopsmart/render-j2-action@v2
+        uses: shopsmart/render-j2-action@feature/multiple-data-files
         with:
           template: ${{ inputs.template }}
           data: ${{ inputs.data }}

--- a/.github/workflows/render-task-definition.yml
+++ b/.github/workflows/render-task-definition.yml
@@ -66,6 +66,11 @@ on:
         type: string
         required: false
         default: 'task-definition.yml' # Changed default
+      debug:
+        description: 'If true, sets -x in the shell command'
+        type: boolean
+        required: false
+        default: false
       # end shopsmart/render-j2-action inputs
 
       artifact-name:
@@ -108,6 +113,7 @@ jobs:
           customize: ${{ inputs.customize }}
           undefined: ${{ inputs.undefined }}
           output: ${{ inputs.output }}
+          debug: ${{ inputs.debug }}
 
       - name: 'Upload task definition'
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

The render-j2-action v2 will remove set-output warnings and allow us to make use of new features to the action.

## Solution

<!-- How does this change fix the problem? -->

Bumps the render-j2-action to v2.

## Notes

<!-- Additional notes here -->
