### PR TITLE
Adds slack notifications to build-ecr-image and register-task-definition

### DIFF
--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -258,7 +258,7 @@ jobs:
 
       - name: 'Notify slack of deployment started'
         if: inputs.notify-slack == true
-        uses: shopsmart/github-actions/actions/notify-slack@v2
+        uses: shopsmart/github-actions/actions/notify-slack@feature/notify-slack-on-deploy
         with:
           application: ${{ inputs.application }}
           status: started
@@ -389,7 +389,7 @@ jobs:
 
       - name: 'Notify slack of deployment started'
         if: always() && inputs.notify-slack == true
-        uses: shopsmart/github-actions/actions/notify-slack@v2
+        uses: shopsmart/github-actions/actions/notify-slack@feature/notify-slack-on-deploy
         with:
           application: ${{ inputs.application }}
           status: ${{ job.status }}

--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -257,7 +257,7 @@ jobs:
           echo "sha=$sha" >> $GITHUB_OUTPUT
 
       - name: 'Notify slack of deployment started'
-        if: inputs.notify-slack == 'true'
+        if: inputs.notify-slack == true
         uses: shopsmart/github-actions/actions/notify-slack@v2
         with:
           application: ${{ inputs.application }}
@@ -388,7 +388,7 @@ jobs:
           token: ${{ secrets.github-token || github.token }}
 
       - name: 'Notify slack of deployment started'
-        if: always() && inputs.notify-slack == 'true'
+        if: always() && inputs.notify-slack == true
         uses: shopsmart/github-actions/actions/notify-slack@v2
         with:
           application: ${{ inputs.application }}

--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -256,7 +256,7 @@ jobs:
           sha="$(git rev-parse HEAD)"
           echo "sha=$sha" >> $GITHUB_OUTPUT
 
-      - name: 'Notify slack of deployment started'
+      - name: 'Notify slack of build started'
         if: inputs.notify-slack == true
         uses: shopsmart/github-actions/actions/notify-slack@feature/notify-slack-on-deploy
         with:
@@ -387,7 +387,7 @@ jobs:
           files: docker-image-*.tgz
           token: ${{ secrets.github-token || github.token }}
 
-      - name: 'Notify slack of deployment started'
+      - name: 'Notify slack of build status'
         if: always() && inputs.notify-slack == true
         uses: shopsmart/github-actions/actions/notify-slack@feature/notify-slack-on-deploy
         with:

--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -258,7 +258,7 @@ jobs:
 
       - name: 'Notify slack of build started'
         if: inputs.notify-slack == true
-        uses: shopsmart/github-actions/actions/notify-slack@feature/notify-slack-on-deploy
+        uses: shopsmart/github-actions/actions/notify-slack@v2
         with:
           application: ${{ inputs.application }}
           status: started
@@ -389,7 +389,7 @@ jobs:
 
       - name: 'Notify slack of build status'
         if: always() && inputs.notify-slack == true
-        uses: shopsmart/github-actions/actions/notify-slack@feature/notify-slack-on-deploy
+        uses: shopsmart/github-actions/actions/notify-slack@v2
         with:
           application: ${{ inputs.application }}
           status: ${{ job.status }}

--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -393,7 +393,7 @@ jobs:
         with:
           application: ${{ inputs.application }}
           status: ${{ job.status }}
-          type: deployment
+          type: build
           template: ${{ inputs.slack-template }}
           version: ${{ inputs.ref || steps.sha.outputs.sha }}
           slack-webhook-url: ${{ secrets.slack-webhook-url }}

--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -195,6 +195,22 @@ on:
         type: string
       # end docker/build-push-action inputs
 
+      # notify-slack
+      notify-slack:
+        description: 'Indicates if a slack notification should go out before and after the deploy'
+        type: boolean
+        default: false
+
+      application:
+        description: 'The name of the application; required if notify-slack is true'
+        type: string
+        required: false
+
+      slack-template:
+        description: 'The j2 template to pass to the notify-slack action'
+        type: string
+        required: false
+
     secrets:
       aws-account-id:
         description: 'The AWS account id that the ecr repository lives under'
@@ -210,6 +226,10 @@ on:
 
       github-token:
         description: "GitHub Token used to authenticate against a repository for Git context"
+        required: false
+
+      slack-webhook-url:
+        description: 'The webhook URL to send the slack notification to; requires notify-slack to be true'
         required: false
 
 env:
@@ -235,6 +255,17 @@ jobs:
         run: |
           sha="$(git rev-parse HEAD)"
           echo "sha=$sha" >> $GITHUB_OUTPUT
+
+      - name: 'Notify slack of deployment started'
+        if: inputs.notify-slack == 'true'
+        uses: shopsmart/github-actions/actions/notify-slack@v2
+        with:
+          application: ${{ inputs.application }}
+          status: started
+          type: build
+          template: ${{ inputs.slack-template }}
+          version: ${{ inputs.ref || steps.sha.outputs.sha }}
+          slack-webhook-url: ${{ secrets.slack-webhook-url }}
 
       - name: 'Is github release?'
         id: is-gh-release
@@ -355,3 +386,14 @@ jobs:
           tag_name: ${{ inputs.ref }}
           files: docker-image-*.tgz
           token: ${{ secrets.github-token || github.token }}
+
+      - name: 'Notify slack of deployment started'
+        if: always() && inputs.notify-slack == 'true'
+        uses: shopsmart/github-actions/actions/notify-slack@v2
+        with:
+          application: ${{ inputs.application }}
+          status: ${{ job.status }}
+          type: deployment
+          template: ${{ inputs.slack-template }}
+          version: ${{ inputs.ref || steps.sha.outputs.sha }}
+          slack-webhook-url: ${{ secrets.slack-webhook-url }}

--- a/.github/workflows/register-task-definition.yml
+++ b/.github/workflows/register-task-definition.yml
@@ -99,6 +99,11 @@ on:
         type: string
         required: false
 
+      link:
+        description: 'The link to the application'
+        type: string
+        required: false
+
     secrets:
       aws-account-id:
         description: 'The AWS account id that the ecr repository lives under'
@@ -143,6 +148,7 @@ jobs:
           type: deployment
           template: ${{ inputs.slack-template }}
           version: ${{ inputs.version }}
+          link: ${{ inputs.link }}
           slack-webhook-url: ${{ secrets.slack-webhook-url }}
 
       - name: 'Download task-definition'
@@ -200,4 +206,5 @@ jobs:
           type: deployment
           template: ${{ inputs.slack-template }}
           version: ${{ inputs.version }}
+          link: ${{ inputs.link }}
           slack-webhook-url: ${{ secrets.slack-webhook-url }}

--- a/.github/workflows/register-task-definition.yml
+++ b/.github/workflows/register-task-definition.yml
@@ -135,7 +135,7 @@ jobs:
     steps:
       - name: 'Notify slack of deployment started'
         if: inputs.notify-slack == true
-        uses: shopsmart/github-actions/actions/notify-slack@feature/notify-slack-on-deploy
+        uses: shopsmart/github-actions/actions/notify-slack@v2
         with:
           application: ${{ inputs.application }}
           environment: ${{ inputs.environment }}
@@ -192,7 +192,7 @@ jobs:
 
       - name: 'Notify slack of deployment status'
         if: always() && inputs.notify-slack == true
-        uses: shopsmart/github-actions/actions/notify-slack@feature/notify-slack-on-deploy
+        uses: shopsmart/github-actions/actions/notify-slack@v2
         with:
           application: ${{ inputs.application }}
           environment: ${{ inputs.environment }}

--- a/.github/workflows/register-task-definition.yml
+++ b/.github/workflows/register-task-definition.yml
@@ -134,7 +134,7 @@ jobs:
       revision-number: ${{ steps.revision.outputs.revision-number }}
     steps:
       - name: 'Notify slack of deployment started'
-        if: inputs.notify-slack == 'true'
+        if: inputs.notify-slack == true
         uses: shopsmart/github-actions/actions/notify-slack@feature/notify-slack-on-deploy
         with:
           application: ${{ inputs.application }}
@@ -190,8 +190,8 @@ jobs:
         env:
           TASK_DEFINITION_ARN: ${{ steps.register.outputs.task-definition-arn }}
 
-      - name: 'Notify slack of deployment started'
-        if: always() && inputs.notify-slack == 'true'
+      - name: 'Notify slack of deployment status'
+        if: always() && inputs.notify-slack == true
         uses: shopsmart/github-actions/actions/notify-slack@feature/notify-slack-on-deploy
         with:
           application: ${{ inputs.application }}

--- a/.github/workflows/register-task-definition.yml
+++ b/.github/workflows/register-task-definition.yml
@@ -78,10 +78,35 @@ on:
         type: string
         default: task-definition
 
+      # notify-slack
+      notify-slack:
+        description: 'Indicates if a slack notification should go out before and after the deploy'
+        type: boolean
+        default: false
+
+      application:
+        description: 'The name of the application; required if notify-slack is true'
+        type: string
+        required: false
+
+      slack-template:
+        description: 'The j2 template to pass to the notify-slack action'
+        type: string
+        required: false
+
+      version:
+        description: 'The version of the application being deployed; required if notify-slack is true'
+        type: string
+        required: false
+
     secrets:
       aws-account-id:
         description: 'The AWS account id that the ecr repository lives under'
         required: true
+
+      slack-webhook-url:
+        description: 'The webhook URL to send the slack notification to; requires notify-slack to be true'
+        required: false
 
     outputs:
       revision-number:
@@ -108,6 +133,18 @@ jobs:
     outputs:
       revision-number: ${{ steps.revision.outputs.revision-number }}
     steps:
+      - name: 'Notify slack of deployment started'
+        if: inputs.notify-slack == 'true'
+        uses: shopsmart/github-actions/actions/notify-slack@v2
+        with:
+          application: ${{ inputs.application }}
+          environment: ${{ inputs.environment }}
+          status: started
+          type: deployment
+          template: ${{ inputs.slack-template }}
+          version: ${{ inputs.version }}
+          slack-webhook-url: ${{ secrets.slack-webhook-url }}
+
       - name: 'Download task-definition'
         uses: actions/download-artifact@v3
         with:
@@ -152,3 +189,15 @@ jobs:
         run: echo "revision-number=${TASK_DEFINITION_ARN##*:}" >> $GITHUB_OUTPUT
         env:
           TASK_DEFINITION_ARN: ${{ steps.register.outputs.task-definition-arn }}
+
+      - name: 'Notify slack of deployment started'
+        if: always() && inputs.notify-slack == 'true'
+        uses: shopsmart/github-actions/actions/notify-slack@v2
+        with:
+          application: ${{ inputs.application }}
+          environment: ${{ inputs.environment }}
+          status: ${{ job.status }}
+          type: deployment
+          template: ${{ inputs.slack-template }}
+          version: ${{ inputs.version }}
+          slack-webhook-url: ${{ secrets.slack-webhook-url }}

--- a/.github/workflows/register-task-definition.yml
+++ b/.github/workflows/register-task-definition.yml
@@ -144,11 +144,11 @@ jobs:
         with:
           application: ${{ inputs.application }}
           environment: ${{ inputs.environment }}
+          link: ${{ inputs.link }}
           status: started
           type: deployment
           template: ${{ inputs.slack-template }}
           version: ${{ inputs.version }}
-          link: ${{ inputs.link }}
           slack-webhook-url: ${{ secrets.slack-webhook-url }}
 
       - name: 'Download task-definition'
@@ -202,9 +202,9 @@ jobs:
         with:
           application: ${{ inputs.application }}
           environment: ${{ inputs.environment }}
+          link: ${{ inputs.link }}
           status: ${{ job.status }}
           type: deployment
           template: ${{ inputs.slack-template }}
           version: ${{ inputs.version }}
-          link: ${{ inputs.link }}
           slack-webhook-url: ${{ secrets.slack-webhook-url }}

--- a/.github/workflows/register-task-definition.yml
+++ b/.github/workflows/register-task-definition.yml
@@ -135,7 +135,7 @@ jobs:
     steps:
       - name: 'Notify slack of deployment started'
         if: inputs.notify-slack == 'true'
-        uses: shopsmart/github-actions/actions/notify-slack@v2
+        uses: shopsmart/github-actions/actions/notify-slack@feature/notify-slack-on-deploy
         with:
           application: ${{ inputs.application }}
           environment: ${{ inputs.environment }}
@@ -192,7 +192,7 @@ jobs:
 
       - name: 'Notify slack of deployment started'
         if: always() && inputs.notify-slack == 'true'
-        uses: shopsmart/github-actions/actions/notify-slack@v2
+        uses: shopsmart/github-actions/actions/notify-slack@feature/notify-slack-on-deploy
         with:
           application: ${{ inputs.application }}
           environment: ${{ inputs.environment }}

--- a/actions/notify-slack/action.yml
+++ b/actions/notify-slack/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: 'The status of the deployment.  Options are started, success, and failure'
     type: string
     required: true
+  link:
+    description: 'The link to the application'
+    type: string
+    required: false
   slack-webhook-url:
     description: 'The slack webhook url to post the message to'
     required: true

--- a/actions/notify-slack/action.yml
+++ b/actions/notify-slack/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: 'The friendly name for the application'
     type: string
     required: true
+  environment:
+    description: 'The environment this ${type} is being performed for'
+    type: string
+    required: false
   emoji:
     description: 'The github release emoji to display'
     default: ''
@@ -40,7 +44,7 @@ inputs:
     type: string
     required: false
     default: ''
-  environment:
+  env_vars:
     description: |
       The environment variables to pass to the render.  Each environment variable should be in format VAR=VAL with one on each line.
       Example:
@@ -108,7 +112,7 @@ runs:
           LINK=${{ inputs.link }}
           REPOSITORY=${{ github.repository }}
           TIMESTAMP=${{ steps.info.outputs.timestamp }}
-          ${{ inputs.environment }}
+          ${{ inputs.env_vars }}
         filters: ${{ inputs.filters }}
         format: ${{ inputs.format }}
         template: ${{ steps.info.outputs.template }}

--- a/actions/notify-slack/action.yml
+++ b/actions/notify-slack/action.yml
@@ -93,6 +93,10 @@ runs:
         TYPE: ${{ inputs.type }}
         VERSION: ${{ inputs.version }}
 
+    - name: 'Debug'
+      shell: bash
+      run: echo "'${{ inputs.environment }}'"
+
     - name: 'Render payload'
       id: render
       uses: shopsmart/render-j2-action@v2

--- a/actions/notify-slack/action.yml
+++ b/actions/notify-slack/action.yml
@@ -93,10 +93,6 @@ runs:
         TYPE: ${{ inputs.type }}
         VERSION: ${{ inputs.version }}
 
-    - name: 'Debug'
-      shell: bash
-      run: echo "'${{ inputs.environment }}'"
-
     - name: 'Render payload'
       id: render
       uses: shopsmart/render-j2-action@v2

--- a/actions/notify-slack/action.yml
+++ b/actions/notify-slack/action.yml
@@ -11,7 +11,7 @@ inputs:
   environment:
     description: 'The environment this ${type} is being performed for'
     type: string
-    required: false
+    default: ''
   emoji:
     description: 'The github release emoji to display'
     default: ''

--- a/actions/notify-slack/get-info.bats
+++ b/actions/notify-slack/get-info.bats
@@ -59,6 +59,17 @@ function teardown() {
   grep -q 'emoji=white_circle' "$GITHUB_OUTPUT"
 }
 
+@test "it should set MESSAGE to default value and not include \"to \$ENVIRONMENT\" if MESSAGE AND ENVIRONMENT are not set and STATUS is not started" {
+  TYPE=test
+  APPLICATION=github-actions
+  VERSION=1.0
+  STATUS=success
+  run get-info
+
+  [ "$status" -eq 0 ]
+  grep -q 'message=A test for github-actions:1.0 resulted in success' "$GITHUB_OUTPUT"
+}
+
 @test "it should set MESSAGE to default value if not set and STATUS is not started" {
   TYPE=test
   APPLICATION=github-actions
@@ -81,6 +92,17 @@ function teardown() {
 
   [ "$status" -eq 0 ]
   grep -q 'message=A test has been started for github-actions:2.0 to staging' "$GITHUB_OUTPUT"
+}
+
+@test "it should set MESSAGE to custom value and not include \"to \$ENVIRONMENT\" if MESSAGE and ENVIRONMENT are not set and STATUS is started" {
+  TYPE=test
+  APPLICATION=github-actions
+  VERSION=2.0
+  STATUS=started
+  run get-info
+
+  [ "$status" -eq 0 ]
+  grep -q 'message=A test has been started for github-actions:2.0' "$GITHUB_OUTPUT"
 }
 
 @test "it should set TIMESTAMP to current timestamp" {

--- a/actions/notify-slack/get-info.sh
+++ b/actions/notify-slack/get-info.sh
@@ -22,10 +22,15 @@ function get-info() {
   echo emoji="$EMOJI" >>"$GITHUB_OUTPUT"
 
   if [ -z "${MESSAGE:-}" ]; then
-    MESSAGE="A $TYPE for ${APPLICATION}:${VERSION} to ${ENVIRONMENT} resulted in ${STATUS}"
+    local to_env=''
+    if [ -n "${ENVIRONMENT:-}" ]; then
+      to_env=" to ${ENVIRONMENT}"
+    fi
+
+    MESSAGE="A $TYPE for ${APPLICATION}:${VERSION}${to_env} resulted in ${STATUS}"
 
     if [ "$STATUS" = started ]; then
-      MESSAGE="A $TYPE has been started for $APPLICATION:$VERSION to $ENVIRONMENT"
+      MESSAGE="A $TYPE has been started for $APPLICATION:$VERSION${to_env}"
     fi
   fi
   echo "message=${MESSAGE:-}" >>"$GITHUB_OUTPUT"

--- a/actions/notify-slack/message.json.j2
+++ b/actions/notify-slack/message.json.j2
@@ -1,3 +1,4 @@
+{%- set environment = env("ENVIRONEMNT", "") -%}
 {
   "blocks": [
     {
@@ -53,10 +54,12 @@
         {
           "type": "mrkdwn",
           {% set link = env("LINK", '') -%}
-          {%- if link == '' -%}
-          "text": "{{ env("ENVIRONMENT") }}"
+          {%- if link != '' and environment != '' -%}
+          "text": "<{{ link }}|{{ environment }}>"
+          {%- elif link == '' and environment != '' -%}
+          "text": "{{ environment }}"
           {%- else -%}
-          "text": "<{{ link }}|{{ env("ENVIRONMENT") }}>"
+          "text": "NONE"
           {%- endif %}
         },
         {

--- a/actions/notify-slack/message.json.j2
+++ b/actions/notify-slack/message.json.j2
@@ -32,7 +32,7 @@
         },
         {
           "type": "mrkdwn",
-          "text": "<https://github.com/{{ env("REPOSITORY") }}|{{ env("REPOSITORY") }}>"
+          "text": "<https://github.com/{{ env("REPOSITORY") }}|{{ env("APPLICATION") }}>"
         },
         {
           "type": "mrkdwn",

--- a/actions/notify-slack/message.json.j2
+++ b/actions/notify-slack/message.json.j2
@@ -1,4 +1,4 @@
-{%- set environment = env("ENVIRONEMNT", "") -%}
+{%- set environment = env("ENVIRONMENT", "") -%}
 {
   "blocks": [
     {


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

We would like slack notifications on builds and deploys.

## Solution

<!-- How does this change fix the problem? -->

Adds notify-slack options to build-ecr-image and register-task-definition workflows.

Also corrects environment in notify-slack action.

## Notes

<!-- Additional notes here -->
