### PR TITLE
Allows repository to be specified in is-gh-release

### DIFF
--- a/.github/actions/test-is-gh-release/action.yml
+++ b/.github/actions/test-is-gh-release/action.yml
@@ -41,6 +41,14 @@ runs:
       with:
         ref: v2.0.2
 
+    # cli/cli v2.3.0
+    - name: 'cli/cli v2.3.0: Is GH release?'
+      id: cli_cli_v2_3_0
+      uses: ./actions/is-gh-release
+      with:
+        ref: v2.3.0
+        repository: cli/cli
+
     - name: 'Validate'
       shell: bash
       run: bats -r ${{ github.action_path }}/is-gh-release.bats
@@ -48,3 +56,4 @@ runs:
         EMPTY_STRING_IS_RELEASE: ${{ steps.empty_string.outputs.is-release }}
         NOTHERE_IS_RELEASE: ${{ steps.nothere.outputs.is-release }}
         V2_0_2_IS_RELEASE: ${{ steps.v2_0_2.outputs.is-release }}
+        CLI_CLI_V2_3_0_IS_RELEASE: ${{ steps.cli_cli_v2_3_0.outputs.is-release }}

--- a/.github/actions/test-is-gh-release/is-gh-release.bats
+++ b/.github/actions/test-is-gh-release/is-gh-release.bats
@@ -25,3 +25,9 @@ function teardown() {
 
   [ "$status" -eq 0 ]
 }
+
+@test "it should consider cli/cli v2.3.0 a release" {
+  run [ "$CLI_CLI_V2_3_0_IS_RELEASE" = 'true' ]
+
+  [ "$status" -eq 0 ]
+}

--- a/actions/is-gh-release/action.yml
+++ b/actions/is-gh-release/action.yml
@@ -12,7 +12,7 @@ inputs:
   repository:
     description: 'The repository to search for the release under'
     type: string
-    default: ${{ github.repository	 }}
+    default: ${{ github.repository }}
 
 outputs:
   is-release:

--- a/actions/is-gh-release/action.yml
+++ b/actions/is-gh-release/action.yml
@@ -9,6 +9,10 @@ inputs:
     required: true
     type: string
     default: ''
+  repository:
+    description: 'The repository to search for the release under'
+    type: string
+    default: ${{ github.repository	 }}
 
 outputs:
   is-release:
@@ -24,3 +28,4 @@ runs:
       run: ${{ github.action_path }}/is-gh-release.sh "${{ inputs.ref }}"
       env:
         GH_TOKEN: ${{ github.token }}
+        REPOSITORY: ${{ inputs.repository }}

--- a/actions/is-gh-release/is-gh-release.bats
+++ b/actions/is-gh-release/is-gh-release.bats
@@ -13,6 +13,7 @@ function teardown() {
 
 function gh() {
   echo "$*" >> "$GH_CMD_FILE"
+  shift 2 # -R "$REPOSITORY"
   if [ "$1 $2" = "release view" ]; then
     if [[ "$3" =~ v.* ]]; then
       echo "release found"

--- a/actions/is-gh-release/is-gh-release.sh
+++ b/actions/is-gh-release/is-gh-release.sh
@@ -5,7 +5,7 @@ function is-gh-release() {
   local is_release=false
 
   if [ -n "$ref" ]; then
-    if gh release view "$ref"; then
+    if gh -R "$REPOSITORY" release view "$ref"; then
       echo "::debug::The $ref ref is a release"
       is_release=true
     else


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

The is-gh-release requires a checkout prior to successfully work.

## Solution

<!-- How does this change fix the problem? -->

Allowing repository to be specified in is-gh-release not only allows looking up releases on a repo other than its own, it fixes an issue where a checkout is not performed prior.

## Notes

<!-- Additional notes here -->

