### PR TITLE
Builds the docker image with the ref provided

### DIFF
--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -336,7 +336,7 @@ jobs:
           cache-from: ${{ inputs.cache-from }}
           cache-to: ${{ inputs.cache-to }}
           cgroup-parent: ${{ inputs.cgroup-parent }}
-          context: ${{ steps.context.outputs.context || inputs.context }}
+          context: ${{ inputs.context }}
           file: ${{ inputs.file }}
           labels: |
             github.sha=${{ steps.sha.outputs.sha }}

--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -117,7 +117,8 @@ on:
         description: "Build's context is the set of files located in the specified PATH or URL"
         required: false
         type: string
-        default: . # to allow the ref change
+        # https://github.com/docker/actions-toolkit/blob/main/src/context.ts#LL48C22-L48C31
+        default: "${{ github.server_url }}/${{ github.repo }}#${{ inputs.ref }}" # to allow the ref change
       file:
         description: "Path to the Dockerfile"
         required: false

--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -117,6 +117,7 @@ on:
         description: "Build's context is the set of files located in the specified PATH or URL"
         required: false
         type: string
+        default: . # uses checkout ref
       file:
         description: "Path to the Dockerfile"
         required: false
@@ -255,14 +256,6 @@ jobs:
         run: |
           sha="$(git rev-parse HEAD)"
           echo "sha=$sha" >> $GITHUB_OUTPUT
-
-      - name: 'Resolve context'
-        id: context
-        if: inputs.ref != '' && ! inputs.context
-        env:
-          # Modified from default: https://github.com/docker/actions-toolkit/blob/main/src/context.ts#LL48C22-L48C31
-          CONTEXT: "${{ github.server_url }}/${{ github.repository }}.git#${{ steps.sha.outputs.sha }}"
-        run: echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
 
       - name: 'Notify slack of build started'
         if: inputs.notify-slack == true

--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -118,7 +118,7 @@ on:
         required: false
         type: string
         # https://github.com/docker/actions-toolkit/blob/main/src/context.ts#LL48C22-L48C31
-        default: "${{ github.server_url }}/${{ github.repo }}#${{ inputs.ref }}" # to allow the ref change
+        default: "${{ github.server_url }}/${{ github.repository }}.git#${{ inputs.ref }}" # to allow the ref change
       file:
         description: "Path to the Dockerfile"
         required: false

--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -117,8 +117,6 @@ on:
         description: "Build's context is the set of files located in the specified PATH or URL"
         required: false
         type: string
-        # https://github.com/docker/actions-toolkit/blob/main/src/context.ts#LL48C22-L48C31
-        default: "${{ github.server_url }}/${{ github.repository }}.git#${{ inputs.ref }}" # to allow the ref change
       file:
         description: "Path to the Dockerfile"
         required: false
@@ -258,6 +256,14 @@ jobs:
           sha="$(git rev-parse HEAD)"
           echo "sha=$sha" >> $GITHUB_OUTPUT
 
+      - name: 'Resolve context'
+        id: context
+        if: inputs.ref != '' && ! inputs.context
+        env:
+          # Modified from default: https://github.com/docker/actions-toolkit/blob/main/src/context.ts#LL48C22-L48C31
+          CONTEXT: "${{ github.server_url }}/${{ github.repository }}.git#${{ steps.sha.outputs.sha }}"
+        run: echo "context=$CONTEXT" >> "$GITHUB_OUTPUT"
+
       - name: 'Notify slack of build started'
         if: inputs.notify-slack == true
         uses: shopsmart/github-actions/actions/notify-slack@v2
@@ -337,7 +343,7 @@ jobs:
           cache-from: ${{ inputs.cache-from }}
           cache-to: ${{ inputs.cache-to }}
           cgroup-parent: ${{ inputs.cgroup-parent }}
-          context: ${{ inputs.context }}
+          context: ${{ steps.context.outputs.context || inputs.context }}
           file: ${{ inputs.file }}
           labels: |
             github.sha=${{ steps.sha.outputs.sha }}

--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -117,6 +117,7 @@ on:
         description: "Build's context is the set of files located in the specified PATH or URL"
         required: false
         type: string
+        default: . # to allow the ref change
       file:
         description: "Path to the Dockerfile"
         required: false

--- a/.github/workflows/test-build-ecr-image.yml
+++ b/.github/workflows/test-build-ecr-image.yml
@@ -29,7 +29,6 @@ jobs:
       aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
 
   test-build-ecr-image-workflow:
-    name: 'Uses the build-ecr-image workflow'
     runs-on: ubuntu-latest
     needs: run-build-ecr-image-workflow
     steps:

--- a/.github/workflows/test-build-ecr-image.yml
+++ b/.github/workflows/test-build-ecr-image.yml
@@ -28,6 +28,20 @@ jobs:
     secrets:
       aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
 
+  test-build-ecr-image-workflow:
+    name: 'Uses the build-ecr-image workflow'
+    runs-on: ubuntu-latest
+    needs: run-build-ecr-image-workflow
+    steps:
+      - name: 'Checkout actions'
+        uses: actions/checkout@v2
+
+      - name: 'Test build-ecr-image workflow'
+        uses: ./.github/actions/test-build-ecr-image
+        with:
+          aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
+          ref: ${{ github.sha }}
+
   # Build for Branch name
   run-build-ecr-image-workflow-on-branch-name:
     uses: ./.github/workflows/build-ecr-image.yml
@@ -51,20 +65,6 @@ jobs:
       ref: ${{ github.sha }}
     secrets:
       aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
-
-  test-build-ecr-image-workflow:
-    name: 'Uses the build-ecr-image workflow'
-    runs-on: ubuntu-latest
-    needs: run-build-ecr-image-workflow
-    steps:
-      - name: 'Checkout actions'
-        uses: actions/checkout@v2
-
-      - name: 'Test build-ecr-image workflow'
-        uses: ./.github/actions/test-build-ecr-image
-        with:
-          aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
-          ref: ${{ github.sha }}
 
   # Build for Tag
   run-build-ecr-image-workflow-tag:

--- a/.github/workflows/test-build-ecr-image.yml
+++ b/.github/workflows/test-build-ecr-image.yml
@@ -70,11 +70,11 @@ jobs:
   run-build-ecr-image-workflow-tag:
     uses: ./.github/workflows/build-ecr-image.yml
     with:
-      ref: v2.2.0-rc.0
+      ref: v2.6.4-rc.0
       file: .github/actions/test-build-ecr-image/Dockerfile
       repository-name: github-actions-tests
       role-name: github-actions-tests
-      build-args: VERSION=v2.2.0-rc.0
+      build-args: VERSION=v2.6.4-rc.0
     secrets:
       aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
 

--- a/.github/workflows/test-build-ecr-image.yml
+++ b/.github/workflows/test-build-ecr-image.yml
@@ -17,7 +17,7 @@ defaults:
     shell: bash
 
 jobs:
-  # Build for Branch
+  # Build for Branch no ref
   run-build-ecr-image-workflow:
     uses: ./.github/workflows/build-ecr-image.yml
     with:
@@ -25,6 +25,30 @@ jobs:
       repository-name: github-actions-tests
       role-name: github-actions-tests
       build-args: VERSION=${{ github.sha }}
+    secrets:
+      aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
+
+  # Build for Branch name
+  run-build-ecr-image-workflow-on-branch-name:
+    uses: ./.github/workflows/build-ecr-image.yml
+    with:
+      file: .github/actions/test-build-ecr-image/Dockerfile
+      repository-name: github-actions-tests
+      role-name: github-actions-tests
+      build-args: VERSION=${{ github.ref_name }}
+      ref: ${{ github.ref_name }}
+    secrets:
+      aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
+
+  # Build for SHA
+  run-build-ecr-image-workflow-on-github-sha:
+    uses: ./.github/workflows/build-ecr-image.yml
+    with:
+      file: .github/actions/test-build-ecr-image/Dockerfile
+      repository-name: github-actions-tests
+      role-name: github-actions-tests
+      build-args: VERSION=${{ github.sha }}
+      ref: ${{ github.sha }}
     secrets:
       aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
 

--- a/.github/workflows/test-build-ecr-image.yml
+++ b/.github/workflows/test-build-ecr-image.yml
@@ -35,8 +35,8 @@ jobs:
       file: .github/actions/test-build-ecr-image/Dockerfile
       repository-name: github-actions-tests
       role-name: github-actions-tests
-      build-args: VERSION=${{ github.ref_name }}
-      ref: ${{ github.ref_name }}
+      build-args: VERSION=${{ github.base_ref }}
+      ref: ${{ github.base_ref }}
     secrets:
       aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
 

--- a/.github/workflows/test-build-ecr-image.yml
+++ b/.github/workflows/test-build-ecr-image.yml
@@ -79,7 +79,6 @@ jobs:
       aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
 
   test-build-ecr-image-workflow-tag:
-    name: 'Uses the build-ecr-image workflow'
     runs-on: ubuntu-latest
     needs: run-build-ecr-image-workflow-tag
     steps:


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

Docker, by default, builds the image from the ref that the workflow is running off of, not the ref we have checked out on.

## Solution

<!-- How does this change fix the problem? -->

For the ref input to actually be used by the docker build, the context must be set to `.`.

## Notes

<!-- Additional notes here -->
