### PR TITLE
Replaces all linuxbrew workarounds with Homebrew/actions/setup-homebrew

### DIFF
--- a/.github/actions/test-deploy-to-s3-bucket/action.yml
+++ b/.github/actions/test-deploy-to-s3-bucket/action.yml
@@ -11,15 +11,12 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: 'Setup Homebrew'
+      uses: Homebrew/actions/setup-homebrew@master
+
     - name: 'Install BATS and jq'
       shell: bash
-      run: |
-        # Add brews to the path
-        echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
-        # Setup brew environment
-        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-        # Install bats
-        brew install bats-core jq
+      run: brew install bats-core jq
 
     - name: 'Checkout'
       uses: actions/checkout@v2

--- a/.github/actions/test-is-gh-release/action.yml
+++ b/.github/actions/test-is-gh-release/action.yml
@@ -6,15 +6,12 @@ description: 'Runs validation against the is-gh-release action'
 runs:
   using: 'composite'
   steps:
+    - name: 'Setup Homebrew'
+      uses: Homebrew/actions/setup-homebrew@master
+
     - name: 'Install BATS'
       shell: bash
-      run: |
-        # Add brews to the path
-        echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
-        # Setup brew environment
-        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-        # Install bats
-        brew install bats-core
+      run: brew install bats-core
 
     - name: 'Checkout'
       uses: actions/checkout@v2

--- a/.github/actions/test-package-archive/action.yml
+++ b/.github/actions/test-package-archive/action.yml
@@ -6,15 +6,12 @@ description: 'Runs validation agains the package-archive action'
 runs:
   using: 'composite'
   steps:
+    - name: 'Setup Homebrew'
+      uses: Homebrew/actions/setup-homebrew@master
+
     - name: 'Install BATS'
       shell: bash
-      run: |
-        # Add brews to the path
-        echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
-        # Setup brew environment
-        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-        # Install bats
-        brew install bats-core
+      run: brew install bats-core
 
     - name: 'Checkout'
       uses: actions/checkout@v2

--- a/.github/actions/test-setup-homebrew/action.yml
+++ b/.github/actions/test-setup-homebrew/action.yml
@@ -6,17 +6,12 @@ description: 'Runs validation against the setup-homebrew action'
 runs:
   using: 'composite'
   steps:
+    - name: 'Setup Homebrew'
+      uses: Homebrew/actions/setup-homebrew@master
+
     - name: 'Install BATS'
       shell: bash
-      run: |
-        if [ "$RUNNER_OS" == Linux ]; then
-          # Add brews to the path
-          echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
-          # Setup brew environment
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-        fi
-        # Install bats
-        brew install bats-core
+      run: brew install bats-core
 
     - name: 'Checkout actions'
       uses: actions/checkout@v2

--- a/.github/actions/test-setup-node/action.yml
+++ b/.github/actions/test-setup-node/action.yml
@@ -6,15 +6,12 @@ description: 'Runs validation agains the setup-node action'
 runs:
   using: 'composite'
   steps:
+    - name: 'Setup Homebrew'
+      uses: Homebrew/actions/setup-homebrew@master
+
     - name: 'Install BATS'
       shell: bash
-      run: |
-        # Add brews to the path
-        echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
-        # Setup brew environment
-        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-        # Install bats
-        brew install bats-core
+      run: brew install bats-core
 
     - name: 'Checkout actions'
       uses: actions/checkout@v2

--- a/.github/actions/test-unpack-archive/action.yml
+++ b/.github/actions/test-unpack-archive/action.yml
@@ -6,15 +6,12 @@ description: 'Runs validation agains the unpack-archive action'
 runs:
   using: 'composite'
   steps:
+    - name: 'Setup Homebrew'
+      uses: Homebrew/actions/setup-homebrew@master
+
     - name: 'Install BATS'
       shell: bash
-      run: |
-        # Add brews to the path
-        echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
-        # Setup brew environment
-        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-        # Install bats
-        brew install bats-core
+      run: brew install bats-core
 
     - name: 'Checkout'
       uses: actions/checkout@v2

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -33,14 +33,11 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@v2
 
+      - name: 'Setup Homebrew'
+        uses: Homebrew/actions/setup-homebrew@master
+
       - name: 'Install bats'
-        run: |
-          # Add brews to the path
-          echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
-          # Setup brew environment
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          # Install bats
-          brew install bats-core
+        run: brew install bats-core
 
       - name: 'Run action tests'
         run: bats -r actions/*/*.bats

--- a/actions/deploy-to-s3-bucket/action.yml
+++ b/actions/deploy-to-s3-bucket/action.yml
@@ -55,15 +55,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: 'Install gh cli'
-      shell: bash
-      run: |
-          echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          brew install gh
-      # Only if we are downloading assets from gh release
-      if: inputs.tag != ''
-
     - name: 'Download release assets'
       shell: bash
       run: gh -R "${{ github.repository }}" release download -p "${{ inputs.pattern }}" "${{ inputs.tag }}"


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

The workaround that Github gave when they removed brew from the runner is no longer valid.  They recommend using the Homebrew action.

## Solution

<!-- How does this change fix the problem? -->

Uses the Homebrew/actions/setup-homebrew action instead of adding to the PATH.

## Notes

<!-- Additional notes here -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205012427455749