### PR TITLE
Refactors deploy-to-s3-bucket action to allow a single file to be uploaded

### DIFF
--- a/.github/actions/test-deploy-to-s3-bucket/action.yml
+++ b/.github/actions/test-deploy-to-s3-bucket/action.yml
@@ -47,6 +47,15 @@ runs:
         s3-bucket: shopsmart-github-actions-tests
         s3-bucket-path: ${{ steps.id.outputs.id }}
 
+    - name: 'Run deploy-to-s3-bucket action uploading the archive itself'
+      id: unpack
+      uses: ./actions/deploy-to-s3-bucket
+      with:
+        pattern: 'archive.tgz'
+        unpack: false
+        s3-bucket: shopsmart-github-actions-tests
+        s3-bucket-path: ${{ steps.id.outputs.id }}/
+
     - name: 'Validate'
       shell: bash
       run: bats -r ${{ github.action_path }}/deploy-to-s3-bucket.bats

--- a/.github/actions/test-deploy-to-s3-bucket/action.yml
+++ b/.github/actions/test-deploy-to-s3-bucket/action.yml
@@ -40,7 +40,6 @@ runs:
         role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/github-actions-tests
 
     - name: 'Run deploy-to-s3-bucket action'
-      id: unpack
       uses: ./actions/deploy-to-s3-bucket
       with:
         pattern: 'archive.tgz'
@@ -48,7 +47,6 @@ runs:
         s3-bucket-path: ${{ steps.id.outputs.id }}
 
     - name: 'Run deploy-to-s3-bucket action uploading the archive itself'
-      id: unpack
       uses: ./actions/deploy-to-s3-bucket
       with:
         pattern: 'archive.tgz'

--- a/.github/actions/test-deploy-to-s3-bucket/action.yml
+++ b/.github/actions/test-deploy-to-s3-bucket/action.yml
@@ -19,7 +19,7 @@ runs:
       run: brew install bats-core jq
 
     - name: 'Checkout'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: 'Use local actions'
       uses: ./.github/actions/use-local-actions
@@ -33,6 +33,12 @@ runs:
       shell: bash
       run: tar -zcvf archive.tgz -C ${{ github.action_path }}/assets .
 
+    - name: 'Configure AWS Credentials'
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: 'us-east-1'
+        role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/github-actions-tests
+
     - name: 'Run deploy-to-s3-bucket action'
       id: unpack
       uses: ./actions/deploy-to-s3-bucket
@@ -40,13 +46,6 @@ runs:
         pattern: 'archive.tgz'
         s3-bucket: shopsmart-github-actions-tests
         s3-bucket-path: ${{ steps.id.outputs.id }}
-        role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/github-actions-tests
-
-    - name: 'Configure AWS Credentials'
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-region: 'us-east-1'
-        role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/github-actions-tests
 
     - name: 'Validate'
       shell: bash

--- a/.github/actions/test-deploy-to-s3-bucket/deploy-to-s3-bucket.bats
+++ b/.github/actions/test-deploy-to-s3-bucket/deploy-to-s3-bucket.bats
@@ -20,8 +20,7 @@ function teardown() {
   run aws s3 cp --recursive "s3://$S3_BUCKET/$S3_BUCKET_PATH" "$BATS_TEST_TMPDIR"
 
   [ "$status" -eq 0 ]
-  [ -f "$BATS_TEST_TMPDIR/index.html" ]
-  [ -f "$BATS_TEST_TMPDIR/style.css" ]
+  [ -f "$BATS_TEST_TMPDIR/assets.tgz" ]
 }
 
 # @test "it should have set the tag on all assets" {

--- a/.github/actions/test-deploy-to-s3-bucket/deploy-to-s3-bucket.bats
+++ b/.github/actions/test-deploy-to-s3-bucket/deploy-to-s3-bucket.bats
@@ -16,6 +16,14 @@ function teardown() {
   [ -f "$BATS_TEST_TMPDIR/style.css" ]
 }
 
+@test "it should have deployed the single asset to the s3 bucket" {
+  run aws s3 cp --recursive "s3://$S3_BUCKET/$S3_BUCKET_PATH" "$BATS_TEST_TMPDIR"
+
+  [ "$status" -eq 0 ]
+  [ -f "$BATS_TEST_TMPDIR/index.html" ]
+  [ -f "$BATS_TEST_TMPDIR/style.css" ]
+}
+
 # @test "it should have set the tag on all assets" {
 #   run aws s3api get-object-tagging \
 #     --bucket $S3_BUCKET \

--- a/.github/actions/test-deploy-to-s3-bucket/deploy-to-s3-bucket.bats
+++ b/.github/actions/test-deploy-to-s3-bucket/deploy-to-s3-bucket.bats
@@ -20,7 +20,7 @@ function teardown() {
   run aws s3 cp --recursive "s3://$S3_BUCKET/$S3_BUCKET_PATH" "$BATS_TEST_TMPDIR"
 
   [ "$status" -eq 0 ]
-  [ -f "$BATS_TEST_TMPDIR/assets.tgz" ]
+  [ -f "$BATS_TEST_TMPDIR/archive.tgz" ]
 }
 
 # @test "it should have set the tag on all assets" {

--- a/actions/deploy-to-s3-bucket/action.yml
+++ b/actions/deploy-to-s3-bucket/action.yml
@@ -9,32 +9,17 @@ inputs:
       If downloading release assets from github, the pattern for the assets file.
       Otherwise, the path to the assets.  If it is an archive, it will unpacked.
     required: true
+  unpack:
+    description: If true, unpacks the pattern as if it were a compressed file.
+    default: 'true'
 
   # GH release Options
   github-token:
     description: 'The github token to allow for searching for release assets'
-    type: string
     default: ${{ github.token }}
   tag:
     description: 'The github release tag to pull that assets from'
     default: ''
-
-  # AWS (S3) Options
-  aws-access-key-id:
-    description: 'The AWS access key id to log into ECR with'
-    default: ''
-  aws-secret-access-key:
-    description: 'The AWS secret access key to log into ECR with'
-    default: ''
-  aws-region:
-    description: 'The AWS region to log into if using ECR'
-    default: 'us-east-1'
-  role-to-assume:
-    description: 'Allows one to configure the assume role'
-    default: ''
-  role-duration-seconds:
-    description: 'Allows one to configure the duration of assume role'
-    default: 1200
 
   s3-bucket:
     description: 'The name of the s3 bucket to upload the assets to'
@@ -65,30 +50,33 @@ runs:
 
     - name: 'Unpack assets'
       id: unpack
+      if: inputs.unpack == 'true'
       uses: shopsmart/github-actions/actions/unpack-archive@v2
       with:
         filename: ${{ inputs.pattern }}
         destination: assets
 
-    - name: 'Configure AWS credentials'
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ inputs.aws-access-key-id }}
-        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
-        aws-region: ${{ inputs.aws-region }}
-        role-to-assume: ${{ inputs.role-to-assume }}
-        role-duration-seconds: ${{ inputs.role-duration-seconds }}
+    - name: 'Resolve assets location'
+      id: assets
+      shell: bash
+      run: |
+        if [ '${{ inputs.unpack }}' == 'true' ]; then
+          LOCATION="${{ steps.unpack.outputs.destination }}"
+        fi
+        echo "location=$LOCATION" >> "$GITHUB_OUTPUT"
+      env:
+        LOCATION: ${{ inputs.pattern }}
 
     - name: 'Upload assets'
       shell: bash
-      run: ${{ github.action_path }}/upload-assets.sh "${{ steps.unpack.outputs.destination }}"
+      run: ${{ github.action_path }}/upload-assets.sh "${{ steps.assets.outputs.location }}"
       env:
         S3_BUCKET: ${{ inputs.s3-bucket }}
         S3_BUCKET_PATH: ${{ inputs.s3-bucket-path }}
 
     - name: 'Tag assets'
       shell: bash
-      run: ${{ github.action_path }}/tag-assets.sh "${{ steps.unpack.outputs.destination }}"
+      run: ${{ github.action_path }}/tag-assets.sh "${{ steps.assets.outputs.location }}"
       env:
         S3_BUCKET: ${{ inputs.s3-bucket }}
         S3_BUCKET_PATH: ${{ inputs.s3-bucket-path }}

--- a/actions/deploy-to-s3-bucket/upload-assets.bats
+++ b/actions/deploy-to-s3-bucket/upload-assets.bats
@@ -8,9 +8,16 @@ function setup() {
 
   export S3_BUCKET=my-s3-bucket
   export S3_BUCKET_PATH=''
+
+  export WORKING_DIRECTORY="$BATS_TEST_TMPDIR/working-directory"
+  mkdir -p "$WORKING_DIRECTORY"
+  pushd "$WORKING_DIRECTORY" &>/dev/null
+
+  mkdir -p my-path
 }
 
 function teardown() {
+  popd &>/dev/null
   rm -f "$AWS_CMD_FILE"
 }
 
@@ -18,20 +25,68 @@ function aws() {
   echo "$*" > "$AWS_CMD_FILE"
 }
 
-@test "it should copy to s3 bucket without path" {
-  run upload-assets my-path
+@test "it should error out if path does not exist" {
+  rmdir my-path
 
-  [ "$status" -eq 0 ]
-  [ -f "$AWS_CMD_FILE" ]
-  [[ "$(< "$AWS_CMD_FILE")" == s3\ cp\ --recursive\ my-path/\ s3://my-s3-bucket/ ]]
+  run upload-assets my-path/
 }
 
-@test "it should copy to s3 bucket with path" {
-  export S3_BUCKET_PATH=my-s3-path
-
+@test "it should attach the slash if path is a directory" {
   run upload-assets my-path
 
   [ "$status" -eq 0 ]
   [ -f "$AWS_CMD_FILE" ]
-  [[ "$(< "$AWS_CMD_FILE")" == s3\ cp\ --recursive\ my-path/\ s3://my-s3-bucket/my-s3-path/ ]]
+  [[ "$(< "$AWS_CMD_FILE")" =~ s3\ cp\ (.*\ )?my-path/\ s3://my-s3-bucket/ ]]
+}
+
+@test "it should attach use the --recursive option if path is a directory" {
+  run upload-assets my-path
+
+  [ "$status" -eq 0 ]
+  [ -f "$AWS_CMD_FILE" ]
+  [[ "$(< "$AWS_CMD_FILE")" =~ s3\ cp\ --recursive\ .* ]]
+}
+
+@test "it should not attach the slash nor options if path is a file" {
+  touch my-path.txt
+
+  run upload-assets my-path.txt
+
+  [ "$status" -eq 0 ]
+  [ -f "$AWS_CMD_FILE" ]
+  [[ "$(< "$AWS_CMD_FILE")" == s3\ cp\ my-path.txt\ s3://my-s3-bucket/ ]]
+}
+
+@test "it should not add additional slashes if slashes are already in the paths" {
+  export S3_BUCKET_PATH=my-s3-path/
+
+  run upload-assets my-path/
+
+  [ "$status" -eq 0 ]
+  [ -f "$AWS_CMD_FILE" ]
+  [[ "$(< "$AWS_CMD_FILE")" =~ s3\ cp\ (.*\ )?my-path/\ s3://my-s3-bucket/my-s3-path/ ]]
+}
+
+@test "it should not add a slash if path is a file and s3-path was provided" {
+  export S3_BUCKET_PATH=my-path.foo
+
+  touch my-path.txt
+
+  run upload-assets "$PWD/my-path.txt"
+
+  [ "$status" -eq 0 ]
+  [ -f "$AWS_CMD_FILE" ]
+  [[ "$(< "$AWS_CMD_FILE")" =~ s3\ cp\ (.*\ )?"$PWD/my-path.txt"\ s3://my-s3-bucket/my-path.foo ]]
+}
+
+@test "it should not add an extra slash if path is a file and s3-path was provided" {
+  export S3_BUCKET_PATH=my-path/
+
+  touch my-path.txt
+
+  run upload-assets "$PWD/my-path.txt"
+
+  [ "$status" -eq 0 ]
+  [ -f "$AWS_CMD_FILE" ]
+  [[ "$(< "$AWS_CMD_FILE")" =~ s3\ cp\ (.*\ )?"$PWD/my-path.txt"\ s3://my-s3-bucket/my-path/ ]]
 }

--- a/actions/deploy-to-s3-bucket/upload-assets.sh
+++ b/actions/deploy-to-s3-bucket/upload-assets.sh
@@ -6,10 +6,31 @@ function upload-assets() {
   local path="$1"
 
   local s3_path="$S3_BUCKET"
-  [ -z "${S3_BUCKET_PATH:-}" ] || s3_path+="/$S3_BUCKET_PATH"
+  if [ -n "${S3_BUCKET_PATH:-}" ] && [ "${s3_path:0:1}" != / ]; then
+    s3_path+="/$S3_BUCKET_PATH"
+  fi
 
-  echo "[DEBUG] Copying $path/ to s3://$s3_path/" >&2
-  aws s3 cp --recursive "$path/" "s3://$s3_path/"
+  local options=()
+
+  if [ -d "$path" ]; then
+    echo "[DEBUG] $path is a directory" >&2
+
+    [ "${path: -1}" = /    ] || path="$path/"
+    [ "${s3_path: -1}" = / ] || s3_path="$s3_path/"
+
+    options+=(--recursive)
+  elif [ -f "$path" ]; then
+    echo "[DEBUG] $path is a file" >&2
+    [ -n "${S3_BUCKET_PATH:-}" ] || s3_path="$s3_path/"
+  else
+    echo "[ERROR] Could not find a file or directory for $path" >&2
+    return 1
+  fi
+
+  echo "[DEBUG] Copying $path to s3://$s3_path" >&2
+  # shellcheck disable=SC2068
+  # We want the options to expand
+  aws s3 cp ${options[@]} "$path" "s3://$s3_path"
 }
 
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

The deploy-to-s3-bucket only allows a directory of assets to be uploaded to an s3 bucket.

## Solution

<!-- How does this change fix the problem? -->

- Allows an individual file to be uploaded to an s3-bucket
- Simplifies deploy-to-s3-bucket action and allows unpacking to be disabled
- Removes authenticating with AWS so it can be updated independently

## Notes

<!-- Additional notes here -->

If looking to drop a file in the s3-path and keep the same name, the s3-path must end in a slash.

```yaml
- uses: shopsmart/github-actions/actions/deploy-to-s3-bucket@v3
  with:
    pattern: my-file.zip
    unpack: false
    s3-bucket: my-s3-bucket
    s3-path: store/staging/
```

Without the slash, it will save the file as `s3://my-s3-bucket/store/staging`.  This is the same convention as running an s3 command.
