### PR TITLE
Puts deploy-to-s3-bucket back to only handling directories

### DIFF
--- a/.github/actions/test-deploy-to-s3-bucket/action.yml
+++ b/.github/actions/test-deploy-to-s3-bucket/action.yml
@@ -19,7 +19,7 @@ runs:
       run: brew install bats-core jq
 
     - name: 'Checkout'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: 'Use local actions'
       uses: ./.github/actions/use-local-actions
@@ -33,24 +33,22 @@ runs:
       shell: bash
       run: tar -zcvf archive.tgz -C ${{ github.action_path }}/assets .
 
+    - name: 'Configure AWS Credentials'
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: 'us-east-1'
+        role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/github-actions-tests
+
     - name: 'Run deploy-to-s3-bucket action'
-      id: unpack
       uses: ./actions/deploy-to-s3-bucket
       with:
         pattern: 'archive.tgz'
         s3-bucket: shopsmart-github-actions-tests
         s3-bucket-path: ${{ steps.id.outputs.id }}
-        role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/github-actions-tests
-
-    - name: 'Configure AWS Credentials'
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-region: 'us-east-1'
-        role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/github-actions-tests
 
     - name: 'Validate'
       shell: bash
-      run: bats -r ${{ github.action_path }}/deploy-to-s3-bucket.bats
+      run: bats --tap --verbose-run ${{ github.action_path }}/deploy-to-s3-bucket.bats
       env:
         S3_BUCKET: shopsmart-github-actions-tests
         S3_BUCKET_PATH: ${{ steps.id.outputs.id }}

--- a/.github/actions/test-deploy-to-s3-bucket/action.yml
+++ b/.github/actions/test-deploy-to-s3-bucket/action.yml
@@ -19,7 +19,7 @@ runs:
       run: brew install bats-core jq
 
     - name: 'Checkout'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v2
 
     - name: 'Use local actions'
       uses: ./.github/actions/use-local-actions
@@ -33,26 +33,20 @@ runs:
       shell: bash
       run: tar -zcvf archive.tgz -C ${{ github.action_path }}/assets .
 
-    - name: 'Configure AWS Credentials'
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        aws-region: 'us-east-1'
-        role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/github-actions-tests
-
     - name: 'Run deploy-to-s3-bucket action'
+      id: unpack
       uses: ./actions/deploy-to-s3-bucket
       with:
         pattern: 'archive.tgz'
         s3-bucket: shopsmart-github-actions-tests
         s3-bucket-path: ${{ steps.id.outputs.id }}
+        role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/github-actions-tests
 
-    - name: 'Run deploy-to-s3-bucket action uploading the archive itself'
-      uses: ./actions/deploy-to-s3-bucket
+    - name: 'Configure AWS Credentials'
+      uses: aws-actions/configure-aws-credentials@v1
       with:
-        pattern: 'archive.tgz'
-        unpack: false
-        s3-bucket: shopsmart-github-actions-tests
-        s3-bucket-path: ${{ steps.id.outputs.id }}/
+        aws-region: 'us-east-1'
+        role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/github-actions-tests
 
     - name: 'Validate'
       shell: bash

--- a/.github/actions/test-deploy-to-s3-bucket/deploy-to-s3-bucket.bats
+++ b/.github/actions/test-deploy-to-s3-bucket/deploy-to-s3-bucket.bats
@@ -16,13 +16,6 @@ function teardown() {
   [ -f "$BATS_TEST_TMPDIR/style.css" ]
 }
 
-@test "it should have deployed the single asset to the s3 bucket" {
-  run aws s3 cp --recursive "s3://$S3_BUCKET/$S3_BUCKET_PATH" "$BATS_TEST_TMPDIR"
-
-  [ "$status" -eq 0 ]
-  [ -f "$BATS_TEST_TMPDIR/archive.tgz" ]
-}
-
 @test "it should have set the tag on assets" {
   run aws s3api get-object-tagging --no-cli-pager \
     --bucket "$S3_BUCKET" \

--- a/.github/actions/test-deploy-to-s3-bucket/deploy-to-s3-bucket.bats
+++ b/.github/actions/test-deploy-to-s3-bucket/deploy-to-s3-bucket.bats
@@ -16,13 +16,29 @@ function teardown() {
   [ -f "$BATS_TEST_TMPDIR/style.css" ]
 }
 
-# @test "it should have set the tag on all assets" {
-#   run aws s3api get-object-tagging \
-#     --bucket $S3_BUCKET \
-#     --key $S3_BUCKET_PATH/index.html \
-#     --no-cli-pager \
-#   | jq -r '.TagSet | to_entries[] | select(.key == "version")'
+@test "it should have deployed the single asset to the s3 bucket" {
+  run aws s3 cp --recursive "s3://$S3_BUCKET/$S3_BUCKET_PATH" "$BATS_TEST_TMPDIR"
 
-#   [ "$status" -eq 0 ]
-#   [ "$output" = "$VERSION" ]
-# }
+  [ "$status" -eq 0 ]
+  [ -f "$BATS_TEST_TMPDIR/archive.tgz" ]
+}
+
+@test "it should have set the tag on assets" {
+  run aws s3api get-object-tagging --no-cli-pager \
+    --bucket "$S3_BUCKET" \
+    --key "$S3_BUCKET_PATH/index.html" \
+    --query 'TagSet[?Key==`test`].Value' \
+    --output text
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ $S3_TAG ]]
+
+  run aws s3api get-object-tagging --no-cli-pager \
+    --bucket "$S3_BUCKET" \
+    --key "$S3_BUCKET_PATH/style.css" \
+    --query 'TagSet[?Key==`test`].Value' \
+    --output text
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ $S3_TAG ]]
+}

--- a/.github/actions/test-deploy-to-s3-bucket/deploy-to-s3-bucket.bats
+++ b/.github/actions/test-deploy-to-s3-bucket/deploy-to-s3-bucket.bats
@@ -16,13 +16,6 @@ function teardown() {
   [ -f "$BATS_TEST_TMPDIR/style.css" ]
 }
 
-@test "it should have deployed the single asset to the s3 bucket" {
-  run aws s3 cp --recursive "s3://$S3_BUCKET/$S3_BUCKET_PATH" "$BATS_TEST_TMPDIR"
-
-  [ "$status" -eq 0 ]
-  [ -f "$BATS_TEST_TMPDIR/archive.tgz" ]
-}
-
 # @test "it should have set the tag on all assets" {
 #   run aws s3api get-object-tagging \
 #     --bucket $S3_BUCKET \

--- a/actions/deploy-to-s3-bucket/action.yml
+++ b/actions/deploy-to-s3-bucket/action.yml
@@ -13,28 +13,10 @@ inputs:
   # GH release Options
   github-token:
     description: 'The github token to allow for searching for release assets'
-    type: string
     default: ${{ github.token }}
   tag:
     description: 'The github release tag to pull that assets from'
     default: ''
-
-  # AWS (S3) Options
-  aws-access-key-id:
-    description: 'The AWS access key id to log into ECR with'
-    default: ''
-  aws-secret-access-key:
-    description: 'The AWS secret access key to log into ECR with'
-    default: ''
-  aws-region:
-    description: 'The AWS region to log into if using ECR'
-    default: 'us-east-1'
-  role-to-assume:
-    description: 'Allows one to configure the assume role'
-    default: ''
-  role-duration-seconds:
-    description: 'Allows one to configure the duration of assume role'
-    default: 1200
 
   s3-bucket:
     description: 'The name of the s3 bucket to upload the assets to'
@@ -69,15 +51,6 @@ runs:
       with:
         filename: ${{ inputs.pattern }}
         destination: assets
-
-    - name: 'Configure AWS credentials'
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ inputs.aws-access-key-id }}
-        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
-        aws-region: ${{ inputs.aws-region }}
-        role-to-assume: ${{ inputs.role-to-assume }}
-        role-duration-seconds: ${{ inputs.role-duration-seconds }}
 
     - name: 'Upload assets'
       shell: bash

--- a/actions/deploy-to-s3-bucket/action.yml
+++ b/actions/deploy-to-s3-bucket/action.yml
@@ -9,17 +9,32 @@ inputs:
       If downloading release assets from github, the pattern for the assets file.
       Otherwise, the path to the assets.  If it is an archive, it will unpacked.
     required: true
-  unpack:
-    description: If true, unpacks the pattern as if it were a compressed file.
-    default: 'true'
 
   # GH release Options
   github-token:
     description: 'The github token to allow for searching for release assets'
+    type: string
     default: ${{ github.token }}
   tag:
     description: 'The github release tag to pull that assets from'
     default: ''
+
+  # AWS (S3) Options
+  aws-access-key-id:
+    description: 'The AWS access key id to log into ECR with'
+    default: ''
+  aws-secret-access-key:
+    description: 'The AWS secret access key to log into ECR with'
+    default: ''
+  aws-region:
+    description: 'The AWS region to log into if using ECR'
+    default: 'us-east-1'
+  role-to-assume:
+    description: 'Allows one to configure the assume role'
+    default: ''
+  role-duration-seconds:
+    description: 'Allows one to configure the duration of assume role'
+    default: 1200
 
   s3-bucket:
     description: 'The name of the s3 bucket to upload the assets to'
@@ -50,33 +65,30 @@ runs:
 
     - name: 'Unpack assets'
       id: unpack
-      if: inputs.unpack == 'true'
       uses: shopsmart/github-actions/actions/unpack-archive@v2
       with:
         filename: ${{ inputs.pattern }}
         destination: assets
 
-    - name: 'Resolve assets location'
-      id: assets
-      shell: bash
-      run: |
-        if [ '${{ inputs.unpack }}' == 'true' ]; then
-          LOCATION="${{ steps.unpack.outputs.destination }}"
-        fi
-        echo "location=$LOCATION" >> "$GITHUB_OUTPUT"
-      env:
-        LOCATION: ${{ inputs.pattern }}
+    - name: 'Configure AWS credentials'
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-region: ${{ inputs.aws-region }}
+        role-to-assume: ${{ inputs.role-to-assume }}
+        role-duration-seconds: ${{ inputs.role-duration-seconds }}
 
     - name: 'Upload assets'
       shell: bash
-      run: ${{ github.action_path }}/upload-assets.sh "${{ steps.assets.outputs.location }}"
+      run: ${{ github.action_path }}/upload-assets.sh "${{ steps.unpack.outputs.destination }}"
       env:
         S3_BUCKET: ${{ inputs.s3-bucket }}
         S3_BUCKET_PATH: ${{ inputs.s3-bucket-path }}
 
     - name: 'Tag assets'
       shell: bash
-      run: ${{ github.action_path }}/tag-assets.sh "${{ steps.assets.outputs.location }}"
+      run: ${{ github.action_path }}/tag-assets.sh "${{ steps.unpack.outputs.destination }}"
       env:
         S3_BUCKET: ${{ inputs.s3-bucket }}
         S3_BUCKET_PATH: ${{ inputs.s3-bucket-path }}

--- a/actions/deploy-to-s3-bucket/upload-assets.bats
+++ b/actions/deploy-to-s3-bucket/upload-assets.bats
@@ -8,16 +8,9 @@ function setup() {
 
   export S3_BUCKET=my-s3-bucket
   export S3_BUCKET_PATH=''
-
-  export WORKING_DIRECTORY="$BATS_TEST_TMPDIR/working-directory"
-  mkdir -p "$WORKING_DIRECTORY"
-  pushd "$WORKING_DIRECTORY" &>/dev/null
-
-  mkdir -p my-path
 }
 
 function teardown() {
-  popd &>/dev/null
   rm -f "$AWS_CMD_FILE"
 }
 
@@ -25,68 +18,20 @@ function aws() {
   echo "$*" > "$AWS_CMD_FILE"
 }
 
-@test "it should error out if path does not exist" {
-  rmdir my-path
-
-  run upload-assets my-path/
-}
-
-@test "it should attach the slash if path is a directory" {
+@test "it should copy to s3 bucket without path" {
   run upload-assets my-path
 
   [ "$status" -eq 0 ]
   [ -f "$AWS_CMD_FILE" ]
-  [[ "$(< "$AWS_CMD_FILE")" =~ s3\ cp\ (.*\ )?my-path/\ s3://my-s3-bucket/ ]]
+  [[ "$(< "$AWS_CMD_FILE")" == s3\ cp\ --recursive\ my-path/\ s3://my-s3-bucket/ ]]
 }
 
-@test "it should attach use the --recursive option if path is a directory" {
+@test "it should copy to s3 bucket with path" {
+  export S3_BUCKET_PATH=my-s3-path
+
   run upload-assets my-path
 
   [ "$status" -eq 0 ]
   [ -f "$AWS_CMD_FILE" ]
-  [[ "$(< "$AWS_CMD_FILE")" =~ s3\ cp\ --recursive\ .* ]]
-}
-
-@test "it should not attach the slash nor options if path is a file" {
-  touch my-path.txt
-
-  run upload-assets my-path.txt
-
-  [ "$status" -eq 0 ]
-  [ -f "$AWS_CMD_FILE" ]
-  [[ "$(< "$AWS_CMD_FILE")" == s3\ cp\ my-path.txt\ s3://my-s3-bucket/ ]]
-}
-
-@test "it should not add additional slashes if slashes are already in the paths" {
-  export S3_BUCKET_PATH=my-s3-path/
-
-  run upload-assets my-path/
-
-  [ "$status" -eq 0 ]
-  [ -f "$AWS_CMD_FILE" ]
-  [[ "$(< "$AWS_CMD_FILE")" =~ s3\ cp\ (.*\ )?my-path/\ s3://my-s3-bucket/my-s3-path/ ]]
-}
-
-@test "it should not add a slash if path is a file and s3-path was provided" {
-  export S3_BUCKET_PATH=my-path.foo
-
-  touch my-path.txt
-
-  run upload-assets "$PWD/my-path.txt"
-
-  [ "$status" -eq 0 ]
-  [ -f "$AWS_CMD_FILE" ]
-  [[ "$(< "$AWS_CMD_FILE")" =~ s3\ cp\ (.*\ )?"$PWD/my-path.txt"\ s3://my-s3-bucket/my-path.foo ]]
-}
-
-@test "it should not add an extra slash if path is a file and s3-path was provided" {
-  export S3_BUCKET_PATH=my-path/
-
-  touch my-path.txt
-
-  run upload-assets "$PWD/my-path.txt"
-
-  [ "$status" -eq 0 ]
-  [ -f "$AWS_CMD_FILE" ]
-  [[ "$(< "$AWS_CMD_FILE")" =~ s3\ cp\ (.*\ )?"$PWD/my-path.txt"\ s3://my-s3-bucket/my-path/ ]]
+  [[ "$(< "$AWS_CMD_FILE")" == s3\ cp\ --recursive\ my-path/\ s3://my-s3-bucket/my-s3-path/ ]]
 }

--- a/actions/deploy-to-s3-bucket/upload-assets.sh
+++ b/actions/deploy-to-s3-bucket/upload-assets.sh
@@ -6,31 +6,10 @@ function upload-assets() {
   local path="$1"
 
   local s3_path="$S3_BUCKET"
-  if [ -n "${S3_BUCKET_PATH:-}" ] && [ "${s3_path:0:1}" != / ]; then
-    s3_path+="/$S3_BUCKET_PATH"
-  fi
+  [ -z "${S3_BUCKET_PATH:-}" ] || s3_path+="/$S3_BUCKET_PATH"
 
-  local options=()
-
-  if [ -d "$path" ]; then
-    echo "[DEBUG] $path is a directory" >&2
-
-    [ "${path: -1}" = /    ] || path="$path/"
-    [ "${s3_path: -1}" = / ] || s3_path="$s3_path/"
-
-    options+=(--recursive)
-  elif [ -f "$path" ]; then
-    echo "[DEBUG] $path is a file" >&2
-    [ -n "${S3_BUCKET_PATH:-}" ] || s3_path="$s3_path/"
-  else
-    echo "[ERROR] Could not find a file or directory for $path" >&2
-    return 1
-  fi
-
-  echo "[DEBUG] Copying $path to s3://$s3_path" >&2
-  # shellcheck disable=SC2068
-  # We want the options to expand
-  aws s3 cp ${options[@]} "$path" "s3://$s3_path"
+  echo "[DEBUG] Copying $path/ to s3://$s3_path/" >&2
+  aws s3 cp --recursive "$path/" "s3://$s3_path/"
 }
 
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

Attempting to have the deploy-to-s3-bucket action to handle directories and a single file has proven to be complicated.

## Solution

<!-- How does this change fix the problem? -->

- Revert "Refactors deploy-to-s3-bucket action to allow a single file to be uploaded (#34)"
- Puts deploy-to-s3-bucket back to only handling directories

## Notes

<!-- Additional notes here -->

This keeps the change that removes configuring aws credentials from within the action.  That still must be handled externally and thus that action can be upgrade independently.
