### PR TITLE
Accepts s3 options when updating lambda functions

### DIFF
--- a/.github/actions/test-deploy-lambda-function/action.yml
+++ b/.github/actions/test-deploy-lambda-function/action.yml
@@ -32,7 +32,7 @@ runs:
         zip archive.zip ./index.js
 
     - name: 'Configure AWS Credentials'
-      uses: aws-actions/configure-aws-credentials@v1-node16
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: 'us-east-1'
         role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/github-actions-tests

--- a/.github/actions/test-deploy-lambda-function/action.yml
+++ b/.github/actions/test-deploy-lambda-function/action.yml
@@ -54,5 +54,5 @@ runs:
         FUNCTION_ARN: arn:aws:lambda:us-east-1:${{ inputs.aws-account-id }}:function:shopsmart-github-actions-tests
         VERSION_TAG: ${{ github.sha }}
         PUBLISHED_VERSION: ${{ steps.deploy.outputs.version }}
-        S3_BUCKET: ${{ steps.deploy.inputs.s3-bucket }}
-        S3_KEY: ${{ steps.deploy.inputs.s3-key }}
+        S3_BUCKET: shopsmart-github-actions-tests
+        S3_KEY: deploy-lambda-function/${{ github.sha }}/lambda.zip

--- a/.github/actions/test-deploy-lambda-function/action.yml
+++ b/.github/actions/test-deploy-lambda-function/action.yml
@@ -31,24 +31,28 @@ runs:
         sed -i "s/const VERSION = 'dev'/const VERSION = '${{ github.sha }}'/" index.js
         zip archive.zip ./index.js
 
-    - name: 'Run deploy-lambda-function action'
-      id: unpack
-      uses: ./actions/deploy-lambda-function
-      with:
-        pattern: ${{ github.action_path }}/archive.zip
-        function-name: shopsmart-github-actions-tests
-        function-tags: version=${{ github.sha }}
-        role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/github-actions-tests
-
     - name: 'Configure AWS Credentials'
       uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         aws-region: 'us-east-1'
         role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/github-actions-tests
 
+    - name: 'Run deploy-lambda-function action'
+      id: deploy
+      uses: ./actions/deploy-lambda-function
+      with:
+        zip-file: ${{ github.action_path }}/archive.zip
+        function-name: shopsmart-github-actions-tests
+        function-tags: version=${{ github.sha }}
+        s3-bucket: shopsmart-github-actions-tests
+        s3-key: deploy-lambda-function/${{ github.sha }}/lambda.zip
+
     - name: 'Validate'
       shell: bash
-      run: bats -r ${{ github.action_path }}/deploy-lambda-function.bats
+      run: bats --tap --verbose-run ${{ github.action_path }}/deploy-lambda-function.bats
       env:
         FUNCTION_ARN: arn:aws:lambda:us-east-1:${{ inputs.aws-account-id }}:function:shopsmart-github-actions-tests
         VERSION_TAG: ${{ github.sha }}
+        PUBLISHED_VERSION: ${{ steps.deploy.outputs.version }}
+        S3_BUCKET: ${{ steps.deploy.inputs.s3-bucket }}
+        S3_KEY: ${{ steps.deploy.inputs.s3-key }}

--- a/.github/workflows/test-deploy-lambda-function.yml
+++ b/.github/workflows/test-deploy-lambda-function.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - actions/deploy-lambda-function/*
       - .github/actions/test-deploy-lambda-function/*
+      - .github/workflows/test-deploy-lambda-function.yml
 
 permissions:
   id-token: write

--- a/actions/deploy-lambda-function/action.yml
+++ b/actions/deploy-lambda-function/action.yml
@@ -45,11 +45,9 @@ runs:
   using: 'composite'
   steps:
     - name: 'Upload lambda code to s3'
+      id: upload-code
       shell: bash
-      run: ${{ github.action_path }}/deploy-lambda.sh "${{ inputs.zip-file }}"
-      env:
-        S3_BUCKET: ${{ inputs.s3-bucket }}
-        S3_KEY: ${{ inputs.s3-key }}
+      run: ${{ github.action_path }}/deploy-lambda.sh "${{ inputs.zip-file }}" "${{ inputs.s3-bucket }}" "${{ inputs.s3-key }}"
       if: inputs.s3-bucket != '' && inputs.upload-to-s3 == 'true'
 
     - name: 'Deploy lambda code'
@@ -57,7 +55,7 @@ runs:
       run: ${{ github.action_path }}/deploy-lambda.sh "${{ inputs.function-name }}" "${{ inputs.zip-file }}"
       env:
         S3_BUCKET: ${{ inputs.s3-bucket }}
-        S3_KEY: ${{ inputs.s3-key }}
+        S3_KEY: ${{ inputs.s3-key || steps.upload-code.outputs.s3-key }}
 
     - name: 'Tag the lambda'
       shell: bash

--- a/actions/deploy-lambda-function/action.yml
+++ b/actions/deploy-lambda-function/action.yml
@@ -47,7 +47,7 @@ runs:
     - name: 'Upload lambda code to s3'
       id: upload-code
       shell: bash
-      run: ${{ github.action_path }}/deploy-lambda.sh "${{ inputs.zip-file }}" "${{ inputs.s3-bucket }}" "${{ inputs.s3-key }}"
+      run: ${{ github.action_path }}/upload-lambda.sh "${{ inputs.zip-file }}" "${{ inputs.s3-bucket }}" "${{ inputs.s3-key }}"
       if: inputs.s3-bucket != '' && inputs.upload-to-s3 == 'true'
 
     - name: 'Deploy lambda code'

--- a/actions/deploy-lambda-function/action.yml
+++ b/actions/deploy-lambda-function/action.yml
@@ -4,43 +4,13 @@ name: 'Deploy lambda function'
 description: 'Deploys a lambda function'
 
 inputs:
-  pattern:
-    description: |
-      If downloading release assets from github, the pattern for the zip file.
-      Otherwise, the path to the zip.
-    type: string
+  zip-file:
+    description: The path to the zip file to upload as the new lambda function code.
     required: true
 
-  # GH release Options
-  github-token:
-    description: 'The github token to allow for searching for release assets'
-    type: string
-    default: ${{ github.token }}
-  tag:
-    description: 'The github release tag to pull that assets from'
-    type: string
-    default: ''
-
-  # AWS (S3) Options
-  aws-access-key-id:
-    description: 'The AWS access key id to log into ECR with'
-    default: ''
-  aws-secret-access-key:
-    description: 'The AWS secret access key to log into ECR with'
-    default: ''
-  aws-region:
-    description: 'The AWS region to log into if using ECR'
-    default: 'us-east-1'
-  role-to-assume:
-    description: 'Allows one to configure the assume role'
-    default: ''
-  role-duration-seconds:
-    description: 'Allows one to configure the duration of assume role'
-    default: 1200
-
+  # Lambda options
   function-name:
     description: The name of the function name
-    type: string
     required: true
   function-tags:
     description: |
@@ -51,30 +21,43 @@ inputs:
           version=v1
           owner=carl
     default: ''
+  publish-version:
+    description: If true, a lambda version will be published
+    default: 'true'
+
+  # s3 options
+  upload-to-s3:
+    description: If true and an s3-bucket is provided, the action will upload the asset to s3 before updating the lambda
+    default: 'true'
+  s3-bucket:
+    description: The s3 bucket to upload the artifact to
+    default: ''
+  s3-key:
+    description: The path within the s3 bucket to upload the artifact to
+    default: ''
+
+outputs:
+  version:
+    description: The version of the lambda that was published (if publish-version is true)
+    value: ${{ steps.publish-version.outputs.version }}
 
 runs:
   using: 'composite'
   steps:
-    - name: 'Download release assets'
+    - name: 'Upload lambda code to s3'
       shell: bash
-      run: gh -R "${{ github.repository }}" release download -p "${{ inputs.pattern }}" "${{ inputs.tag }}"
+      run: ${{ github.action_path }}/deploy-lambda.sh "${{ inputs.zip-file }}"
       env:
-        GH_TOKEN: ${{ inputs.github-token }}
-      # Only if we are downloading assets from gh release
-      if: inputs.tag != ''
-
-    - name: 'Configure AWS credentials'
-      uses: aws-actions/configure-aws-credentials@v1-node16
-      with:
-        aws-access-key-id: ${{ inputs.aws-access-key-id }}
-        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
-        aws-region: ${{ inputs.aws-region }}
-        role-to-assume: ${{ inputs.role-to-assume }}
-        role-duration-seconds: ${{ inputs.role-duration-seconds }}
+        S3_BUCKET: ${{ inputs.s3-bucket }}
+        S3_KEY: ${{ inputs.s3-key }}
+      if: inputs.s3-bucket != '' && inputs.upload-to-s3 == 'true'
 
     - name: 'Deploy lambda code'
       shell: bash
-      run: ${{ github.action_path }}/deploy-lambda.sh "${{ inputs.function-name }}" "${{ inputs.pattern }}"
+      run: ${{ github.action_path }}/deploy-lambda.sh "${{ inputs.function-name }}" "${{ inputs.zip-file }}"
+      env:
+        S3_BUCKET: ${{ inputs.s3-bucket }}
+        S3_KEY: ${{ inputs.s3-key }}
 
     - name: 'Tag the lambda'
       shell: bash
@@ -82,3 +65,9 @@ runs:
       env:
         LAMBDA_TAGS: ${{ inputs.function-tags }}
       if: inputs.function-tags != ''
+
+    - name: 'Cut a version of the lambda'
+      id: publish-version
+      if: inputs.publish-version == 'true'
+      shell: bash
+      run: ${{ github.action_path }}/version-lambda.sh "${{ inputs.function-name }}" "${{ inputs.tag || github.sha }}"

--- a/actions/deploy-lambda-function/deploy-lambda.bats
+++ b/actions/deploy-lambda-function/deploy-lambda.bats
@@ -40,6 +40,15 @@ function aws() {
   [ "$status" -ne 0 ]
 }
 
+@test "it should require an s3 bucket and s3 path if no zip file" {
+  export S3_BUCKET=my-s3-bucket
+  export S3_KEY=''
+
+  run deploy-lambda "$FUNCTION_NAME" ""
+
+  [ "$status" -ne 0 ]
+}
+
 @test "it should require the zip to be an actual file" {
   run deploy-lambda "$FUNCTION_NAME" "$BATS_TEST_DIRNAME/nothere.zip"
 
@@ -66,4 +75,27 @@ function aws() {
   [ "$status" -eq 0 ]
   [ -f "$AWS_CMD_FILE" ]
   [[ "$(< "$AWS_CMD_FILE")" =~ "lambda update-function-code --function-name $LAMBDA_FUNCTION --zip-file fileb://$zip_file" ]]
+}
+
+@test "it should set s3 options" {
+  export S3_BUCKET=my-s3-bucket
+  export S3_KEY=my-s3-key
+
+  run deploy-lambda "$LAMBDA_FUNCTION" "$BATS_TEST_TMPDIR/*.zip"
+
+  [ "$status" -eq 0 ]
+  [ -f "$AWS_CMD_FILE" ]
+  [[ "$(< "$AWS_CMD_FILE")" =~ "lambda update-function-code --function-name $LAMBDA_FUNCTION --s3-bucket $S3_BUCKET --s3-key $S3_KEY" ]]
+}
+
+@test "it should set allow s3 object version" {
+  export S3_BUCKET=my-s3-bucket
+  export S3_KEY=my-s3-key
+  export S3_OBJECT_VERSION=123456
+
+  run deploy-lambda "$LAMBDA_FUNCTION" "$BATS_TEST_TMPDIR/*.zip"
+
+  [ "$status" -eq 0 ]
+  [ -f "$AWS_CMD_FILE" ]
+  [[ "$(< "$AWS_CMD_FILE")" =~ "lambda update-function-code --function-name $LAMBDA_FUNCTION --s3-bucket $S3_BUCKET --s3-key $S3_KEY --s3-object-version $S3_OBJECT_VERSION" ]]
 }

--- a/actions/deploy-lambda-function/deploy-lambda.sh
+++ b/actions/deploy-lambda-function/deploy-lambda.sh
@@ -4,35 +4,53 @@ function deploy-lambda() {
   set -eo pipefail
 
   local function_name="$1"
-  local zip_file="$2"
+  local zip_file="${2:-}"
+  local s3_bucket="${S3_BUCKET:-}"
+  local s3_key="${S3_KEY:-}"
+  local s3_object_version="${S3_OBJECT_VERSION:-}"
 
   # validate
   [ -n "$function_name" ] || {
     echo "[ERROR] A function name must be provided" >&2
     return 1
   }
-  [ -n "$zip_file" ] || {
-    echo "[ERROR] A zip file must be provided" >&2
-    return 2
-  }
-  # resolve zip file if wildcard
-  [ "$zip_file" = "${zip_file#*\*}" ] || {
-    echo "[DEBUG] Found a wildcard file" >&2
-    local pre_wildcard="${zip_file%\**}"
-    local post_wildcard="${zip_file#*\*}"
-    zip_file="$(builtin echo "$pre_wildcard"*"$post_wildcard")"
-    echo "[DEBUG] Expanded '$pre_wildcard*$post_wildcard' to $zip_file" >&2
-  }
-  [ -f "$zip_file" ] || {
-    echo "[ERROR] Zip file does not exist" >&2
-    return 3
-  }
+  if [ -z "$zip_file" ]; then
+    if [ -z "$s3_bucket" ] || [ -z "$s3_key" ]; then
+      echo "[ERROR] A zip file or an s3 bucket and s3 key must be provided" >&2
+      return 2
+    fi
+  fi
 
-  # deploy
-  echo "[DEBUG] Uploading $zip_file to $function_name function" >&2
-  aws lambda update-function-code \
-    --function-name "$function_name" \
-    --zip-file "fileb://$zip_file"
+  local options=()
+
+  if [ -z "$s3_bucket" ] || [ -z "$s3_key" ]; then
+    # resolve zip file if wildcard
+    [ "$zip_file" = "${zip_file#*\*}" ] || {
+      echo "[DEBUG] Found a wildcard file" >&2
+      local pre_wildcard="${zip_file%\**}"
+      local post_wildcard="${zip_file#*\*}"
+      zip_file="$(builtin echo "$pre_wildcard"*"$post_wildcard")"
+      echo "[DEBUG] Expanded '$pre_wildcard*$post_wildcard' to $zip_file" >&2
+    }
+    [ -f "$zip_file" ] || {
+      echo "[ERROR] Zip file does not exist" >&2
+      return 3
+    }
+
+    echo "[DEBUG] Uploading $zip_file to $function_name function" >&2
+    options+=(--zip-file "fileb://$zip_file")
+  else
+    options+=(--s3-bucket "$s3_bucket")
+    options+=(--s3-key "$s3_key")
+    # object version
+    [ -z "$s3_object_version" ] || options+=(--s3-object-version "$s3_object_version")
+
+    echo "[DEBUG] Updating $function_name function to use s3://$s3_bucket/$s3_key#$s3_object_version" >&2
+  fi
+
+  # shellcheck disable=SC2068
+  # We want options to expand here
+  aws lambda update-function-code --function-name "$function_name" ${options[@]}
 }
 
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then

--- a/actions/deploy-lambda-function/upload-lambda.bats
+++ b/actions/deploy-lambda-function/upload-lambda.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+
+load upload-lambda.sh
+
+function setup() {
+  export AWS_CMD_FILE="$BATS_TEST_TMPDIR/aws.cmd"
+  export -f aws
+
+  export GITHUB_OUTPUT="$BATS_TEST_TMPDIR/output.txt"
+
+  export ZIP_FILE="$BATS_TEST_TMPDIR/archive.zip"
+  touch "$ZIP_FILE"
+
+  export S3_BUCKET=my-s3-bucket
+}
+
+function teardown() {
+  rm -f "$AWS_CMD_FILE"
+}
+
+function aws() {
+  echo "$*" > "$AWS_CMD_FILE"
+}
+
+@test "it should require the zip file" {
+  run upload-lambda
+
+  [ "$status" -ne 0 ]
+}
+
+@test "it should error out if the zip file does not exist" {
+  run upload-lambda "$BATS_TEST_TMPDIR/nothere.zip"
+
+  [ "$status" -ne 0 ]
+}
+
+@test "it should require the s3 bucket" {
+  run upload-lambda "$ZIP_FILE"
+
+  [ "$status" -ne 0 ]
+}
+
+@test "it should default the s3 key to the name of the file" {
+  S3_KEY="$(basename "$ZIP_FILE")"
+
+  run upload-lambda "$ZIP_FILE" "$S3_BUCKET"
+
+  [ "$status" -eq 0 ]
+  [ -f "$AWS_CMD_FILE" ]
+  [ "$(< "$AWS_CMD_FILE")" = "s3 cp $ZIP_FILE s3://$S3_BUCKET/$S3_KEY" ]
+  [ -f "$GITHUB_OUTPUT" ]
+  [ "$(< "$GITHUB_OUTPUT")" = "s3-key=$S3_KEY" ]
+}
+
+@test "it should allow the s3-key to be provided" {
+  S3_KEY=my-path/my-artifact.zip
+
+  run upload-lambda "$ZIP_FILE" "$S3_BUCKET" "$S3_KEY"
+
+  [ "$status" -eq 0 ]
+  [ -f "$AWS_CMD_FILE" ]
+  [ "$(< "$AWS_CMD_FILE")" = "s3 cp $ZIP_FILE s3://$S3_BUCKET/$S3_KEY" ]
+  [ -f "$GITHUB_OUTPUT" ]
+  [ "$(< "$GITHUB_OUTPUT")" = "s3-key=$S3_KEY" ]
+}
+
+@test "it should toss out an extra slash" {
+  S3_KEY=my-path/my-artifact.zip
+
+  run upload-lambda "$ZIP_FILE" "$S3_BUCKET" "/$S3_KEY"
+
+  [ "$status" -eq 0 ]
+  [ -f "$AWS_CMD_FILE" ]
+  [ "$(< "$AWS_CMD_FILE")" = "s3 cp $ZIP_FILE s3://$S3_BUCKET/$S3_KEY" ]
+  [ -f "$GITHUB_OUTPUT" ]
+  [ "$(< "$GITHUB_OUTPUT")" = "s3-key=/$S3_KEY" ]
+}

--- a/actions/deploy-lambda-function/upload-lambda.sh
+++ b/actions/deploy-lambda-function/upload-lambda.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+function upload-lambda() {
+  set -eo pipefail
+
+  local zip_file="${1:-}"
+  [ -n "$zip_file" ] || {
+    echo "[ERROR] Zip file is required" >&2
+    return 1
+  }
+  [ -f "$zip_file" ] || {
+    echo "[ERROR] Cannot find zip file: $zip_file" >&2
+    return 2
+  }
+  local s3_bucket="${2:-}"
+  [ -n "$s3_bucket" ] || {
+    echo "[ERROR] S3 bucket is required" >&2
+    return 3
+  }
+
+  local s3_key="${3:-}"
+  [ -n "${s3_key:-}" ] || {
+    echo "[ERROR] Defaulting the s3 key to the basename of the file" >&2
+    s3_key="$(basename "$zip_file")"
+  }
+
+  local s3_path="$s3_bucket/$s3_key"
+  # Replace all double slashes with a single slash
+  s3_path="${s3_path//\/\//\/}"
+
+  echo "[DEBUG] Copying $zip_file to s3://$s3_path" >&2
+  aws s3 cp "$zip_file" "s3://$s3_path"
+
+  echo "s3-key=$s3_key" >> "$GITHUB_OUTPUT"
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  set -u
+
+  upload-lambda "${@:-}"
+  exit $?
+fi

--- a/actions/deploy-lambda-function/version-lambda.bats
+++ b/actions/deploy-lambda-function/version-lambda.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+
+load version-lambda.sh
+
+function setup() {
+  export AWS_CMD_FILE="$BATS_TEST_TMPDIR/aws.cmd"
+  export -f aws
+
+  export LAMBDA_FUNCTION=fake-function
+
+  export GITHUB_OUTPUT="$BATS_TEST_TMPDIR/output.txt"
+}
+
+function teardown() {
+  rm -f "$AWS_CMD_FILE"
+}
+
+function aws() {
+  echo "$*" >> "$AWS_CMD_FILE"
+  echo "1"
+}
+
+@test "it should require a function name" {
+  run version-lambda
+
+  [ "$status" -ne 0 ]
+}
+
+@test "it should require a version" {
+  run version-lambda "$LAMBDA_FUNCTION"
+
+  [ "$status" -ne 0 ]
+}
+
+@test "it should publish a version of the lambda" {
+  run version-lambda "$LAMBDA_FUNCTION" v1.0.0
+
+  [ "$status" -eq 0 ]
+  [ -f "$AWS_CMD_FILE" ]
+  [ "$(< "$AWS_CMD_FILE")" = "lambda publish-version --function-name $LAMBDA_FUNCTION --description v1.0.0 --query Version --output text --no-cli-pager" ]
+}
+
+@test "it should pass the revision id if provided" {
+  export REVISION_ID=123456
+
+  run version-lambda "$LAMBDA_FUNCTION" v1.0.0
+
+  [ "$status" -eq 0 ]
+  [ -f "$AWS_CMD_FILE" ]
+  [ "$(< "$AWS_CMD_FILE")" = "lambda publish-version --function-name $LAMBDA_FUNCTION --description v1.0.0 --revision-id $REVISION_ID --query Version --output text --no-cli-pager" ]
+}
+
+@test "it should output the version number" {
+  run version-lambda "$LAMBDA_FUNCTION" v1.0.0
+
+  [ "$status" -eq 0 ]
+  [ -f "$GITHUB_OUTPUT" ]
+  [ "$(< "$GITHUB_OUTPUT")" = version=1 ]
+}

--- a/actions/deploy-lambda-function/version-lambda.sh
+++ b/actions/deploy-lambda-function/version-lambda.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+function version-lambda() {
+  set -eo pipefail
+
+  local function_name="${1:-}"
+  [ -n "$function_name" ] || {
+    echo "[ERROR] Function name not provided" >&2
+    return 1
+  }
+
+  local description="${2:-}"
+  [ -n "$description" ] || {
+    echo "[ERROR] Version not provided" >&2
+    return 2
+  }
+
+  local revision_id="${REVISION_ID:-}"
+  [ -z "$revision_id" ] || options+=(--revision-id "$revision_id")
+
+  local version=''
+  # shellcheck disable=SC2068
+  # We want options to expand here
+  version="$(
+    aws lambda publish-version \
+      --function-name "$function_name" \
+      --description "$description" \
+      ${options[@]} \
+      --query Version \
+      --output text \
+      --no-cli-pager
+  )"
+  echo "version=$version" >> "$GITHUB_OUTPUT"
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  set -u
+
+  version-lambda "${@:-}"
+  exit $?
+fi


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

We would like to be able to deploy lambda functions from assets deployed to s3.

## Solution

<!-- How does this change fix the problem? -->

Accepts s3 options with the deploy-lambda-function action.

## Notes

The configure-aws-credentials has been pulled out of this action so it can be upgraded independently.  Similarly, downloading the release asset has been removed to simplify what the action covers.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205225249873565
