### PR TITLE
Sets the content-type of the current version file

### DIFF
--- a/.github/workflows/deploy-lambda-function.yml
+++ b/.github/workflows/deploy-lambda-function.yml
@@ -226,8 +226,11 @@ jobs:
           s3_path="${{ inputs.s3-bucket }}/${{ inputs.current-version-path }}"
           # Replace double slashes with single slashses
           s3_path="${s3_path//\/\//\/}"
+
           echo "[DEBUG] Uploading current-version to s3://$s3_path" >&2
-          aws s3 cp current-version "s3://$s3_path"
+          aws s3 cp \
+            --content-type text/plain \
+            current-version "s3://$s3_path"
 
       - name: 'Notify slack of deployment status'
         if: always() && inputs.notify-slack == true


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

Terraform requires that the content-type of the s3 object is set to something human readable such as `text/plain` or `application/json`.  If not set, terraform quietly does not provide the [body attribute](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_object#body).

## Solution

<!-- How does this change fix the problem? -->

Sets the content-type for the current version file.

## Notes

<!-- Additional notes here -->

We can add a test for this, but would need to look up how to get that information without using `file $filename` after download.
