### PR TITLE
Defaults template in the composite action, rather than at the inputs

### DIFF
--- a/actions/notify-slack/action.yml
+++ b/actions/notify-slack/action.yml
@@ -29,7 +29,7 @@ inputs:
   template:
     description: 'The path to the template file to render'
     type: string
-    default: ${{ github.action_path }}/message.json.j2
+    required: false
   status:
     description: 'The status of the deployment.  Options are started, success, and failure'
     type: string
@@ -93,7 +93,7 @@ runs:
         ENVIRONMENT: ${{ inputs.environment }}
         MESSAGE: ${{ inputs.message }}
         STATUS: ${{ inputs.status }}
-        TEMPLATE: ${{ inputs.template }}
+        TEMPLATE: ${{ inputs.template || format('{0}/message.json.j2', github.action_path) }}
         TYPE: ${{ inputs.type }}
         VERSION: ${{ inputs.version }}
 


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

The `${{ github.action_path }}` is coming in as an empty string when using it as a default.

## Solution

<!-- How does this change fix the problem? -->

Defaults when passing it to the shell script.

## Notes

<!-- Additional notes here -->

Currently being used in search-api.

This is the correct PR.  Overlooked this one.