### PR TITLE
Removes `inputs.github-token` in favor of `secrets.github-token`

### DIFF
--- a/.github/workflows/deploy-lambda-function.yml
+++ b/.github/workflows/deploy-lambda-function.yml
@@ -23,10 +23,6 @@ on:
         description: 'If pulling from a github release, the release tag that should be pulled from'
         type: string
         default: ''
-      github-token:
-        description: 'The github token that has read access to the release assets'
-        type: string
-        default: ${{ github.token }}
 
       # AWS options
       role-name: # shorthand
@@ -166,7 +162,7 @@ jobs:
         shell: bash
         run: gh -R "${{ github.repository }}" release download -p "${{ inputs.pattern }}" "${{ inputs.release-tag }}"
         env:
-          GITHUB_TOKEN: ${{ inputs.github-token }}
+          GITHUB_TOKEN: ${{ secrets.github-token || github.token }}
         # Only if we are downloading assets from gh release
         if: inputs.release-tag != ''
 

--- a/.github/workflows/deploy-lambda-function.yml
+++ b/.github/workflows/deploy-lambda-function.yml
@@ -162,7 +162,7 @@ jobs:
         shell: bash
         run: gh -R "${{ github.repository }}" release download -p "${{ inputs.pattern }}" "${{ inputs.release-tag }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.github-token || github.token }}
+          GH_TOKEN: ${{ secrets.github-token || github.token }}
         # Only if we are downloading assets from gh release
         if: inputs.release-tag != ''
 

--- a/actions/deploy-lambda-function/upload-lambda.sh
+++ b/actions/deploy-lambda-function/upload-lambda.sh
@@ -10,11 +10,11 @@ function upload-lambda() {
   }
   # resolve zip file if wildcard
   [ "$zip_file" = "${zip_file#*\*}" ] || {
-    echo "[INFO ] Found a wildcard file" >&2
+    echo "[DEBUG] Found a wildcard file" >&2
     local pre_wildcard="${zip_file%\**}"
     local post_wildcard="${zip_file#*\*}"
     zip_file="$(builtin echo "$pre_wildcard"*"$post_wildcard")"
-    echo "[INFO ] Expanded '$pre_wildcard*$post_wildcard' to $zip_file" >&2
+    echo "[DEBUG] Expanded '$pre_wildcard*$post_wildcard' to $zip_file" >&2
   }
   [ -f "$zip_file" ] || {
     echo "[ERROR] Cannot find zip file: $zip_file" >&2
@@ -37,7 +37,7 @@ function upload-lambda() {
   # Replace all double slashes with a single slash
   s3_path="${s3_path//\/\//\/}"
 
-  echo "[INFO ] Copying $zip_file to s3://$s3_path" >&2
+  echo "[DEBUG] Copying $zip_file to s3://$s3_path" >&2
   aws s3 cp "$zip_file" "s3://$s3_path"
 
   echo "s3-key=$s3_key" >> "$GITHUB_OUTPUT"

--- a/actions/deploy-lambda-function/upload-lambda.sh
+++ b/actions/deploy-lambda-function/upload-lambda.sh
@@ -10,11 +10,11 @@ function upload-lambda() {
   }
   # resolve zip file if wildcard
   [ "$zip_file" = "${zip_file#*\*}" ] || {
-    echo "[DEBUG] Found a wildcard file" >&2
+    echo "[INFO ] Found a wildcard file" >&2
     local pre_wildcard="${zip_file%\**}"
     local post_wildcard="${zip_file#*\*}"
     zip_file="$(builtin echo "$pre_wildcard"*"$post_wildcard")"
-    echo "[DEBUG] Expanded '$pre_wildcard*$post_wildcard' to $zip_file" >&2
+    echo "[INFO ] Expanded '$pre_wildcard*$post_wildcard' to $zip_file" >&2
   }
   [ -f "$zip_file" ] || {
     echo "[ERROR] Cannot find zip file: $zip_file" >&2
@@ -37,7 +37,7 @@ function upload-lambda() {
   # Replace all double slashes with a single slash
   s3_path="${s3_path//\/\//\/}"
 
-  echo "[DEBUG] Copying $zip_file to s3://$s3_path" >&2
+  echo "[INFO ] Copying $zip_file to s3://$s3_path" >&2
   aws s3 cp "$zip_file" "s3://$s3_path"
 
   echo "s3-key=$s3_key" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

The deploy-lambda-function workflow is not pulling GH releases properly.

## Solution

<!-- How does this change fix the problem? -->

- Removes `inputs.github-token` in favor of `secrets.github-token`.
- Corrects the environment variable for gh cli commands.

## Notes

<!-- Additional notes here -->
