### PR TITLE
Upgrades the docker/build-push-action to v5

### DIFF
--- a/.github/actions/test-build-ecr-image/action.yml
+++ b/.github/actions/test-build-ecr-image/action.yml
@@ -41,4 +41,4 @@ runs:
       run: bats --verbose-run -r ${{ github.action_path }}/build-ecr-image.bats
       env:
         ECR_REPOSITORY: ${{ inputs.aws-account-id }}.dkr.ecr.us-east-1.amazonaws.com/github-actions-tests
-        VERSION_TAG: ${{ inputs.ref || github.sha }}
+        VERSION_TAG: ${{ inputs.ref }}

--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -325,7 +325,7 @@ jobs:
           append: ${{ inputs.append }}
 
       - name: 'Build docker image'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           add-hosts: ${{ inputs.add-hosts }}
           allow: ${{ inputs.allow }}

--- a/.github/workflows/test-build-ecr-image.yml
+++ b/.github/workflows/test-build-ecr-image.yml
@@ -88,4 +88,4 @@ jobs:
         uses: ./.github/actions/test-build-ecr-image
         with:
           aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
-          ref: v2.2.0-rc.0
+          ref: v2.6.4-rc.0


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

There is a newer version of the docker/build-push-action.
The cache is causing issues on the older version.

## Solution

<!-- How does this change fix the problem? -->

Upgrade the docker/build-push-action to v5.

## Notes

<!-- Additional notes here -->
