### PR TITLE
Installs an ssh private key for private j2 dependencies

### DIFF
--- a/.github/workflows/render-task-definition.yml
+++ b/.github/workflows/render-task-definition.yml
@@ -82,6 +82,9 @@ on:
       aws-account-id:
         description: 'The AWS account id that the ecr repository lives under'
         required: true
+      ssh-private-key:
+        description: 'An SSH private key to install for private dependencies'
+        required: false
 
 defaults:
   run:
@@ -96,6 +99,20 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
+
+      - name: 'If ssh private key provided, setup ssh agent'
+        id: ssh
+        run: |
+          has_key='false'
+          [ -z "${{ secrets.ssh-private-key }}" ] || has_key='true'
+          echo "has_key=$has_key" >> "$GITHUB_OUTPUT"
+
+      # for private dependencies
+      - name: 'Install SSH Key'
+        if: steps.ssh.outputs.has_key == 'true'
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.ssh-private-key }}
 
       - name: 'Render task definition'
         uses: shopsmart/render-j2-action@v2


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

We would like to start using a private python dependency with our j2 templates.

## Solution

<!-- How does this change fix the problem? -->

Installs an ssh private key before rendering the j2 template if provided.

## Notes

<!-- Additional notes here -->
