### PR TITLE
Sleep for a few seconds before attempting to publish a new lambda version

### DIFF
--- a/.github/workflows/deploy-lambda-function.yml
+++ b/.github/workflows/deploy-lambda-function.yml
@@ -186,7 +186,7 @@ jobs:
       # deploy
       - name: 'Deploy'
         id: deploy
-        uses: shopsmart/github-actions/actions/deploy-lambda-function@v3
+        uses: shopsmart/github-actions/actions/deploy-lambda-function@hotfix/sleep-before-publish-version
         with:
           zip-file: ${{ inputs.pattern }}
           function-name: ${{ inputs.function-name }}

--- a/.github/workflows/deploy-lambda-function.yml
+++ b/.github/workflows/deploy-lambda-function.yml
@@ -186,7 +186,7 @@ jobs:
       # deploy
       - name: 'Deploy'
         id: deploy
-        uses: shopsmart/github-actions/actions/deploy-lambda-function@hotfix/sleep-before-publish-version
+        uses: shopsmart/github-actions/actions/deploy-lambda-function@v3
         with:
           zip-file: ${{ inputs.pattern }}
           function-name: ${{ inputs.function-name }}

--- a/actions/deploy-lambda-function/action.yml
+++ b/actions/deploy-lambda-function/action.yml
@@ -68,7 +68,7 @@ runs:
     #   An update is in progress for resource: arn:aws:lambda:<region>:***:function:<redacted>
     - name: 'Let the function settle'
       shell: bash
-      run: sleep 5 # seconds
+      run: sleep 10 # seconds
 
     - name: 'Cut a version of the lambda'
       id: publish-version

--- a/actions/deploy-lambda-function/action.yml
+++ b/actions/deploy-lambda-function/action.yml
@@ -64,6 +64,12 @@ runs:
         LAMBDA_TAGS: ${{ inputs.function-tags }}
       if: inputs.function-tags != ''
 
+    # An error occurred (ResourceConflictException) when calling the PublishVersion operation: The operation cannot be performed at this time.
+    #   An update is in progress for resource: arn:aws:lambda:<region>:***:function:<redacted>
+    - name: 'Let the function settle'
+      shell: bash
+      run: sleep 10 # seconds
+
     - name: 'Cut a version of the lambda'
       id: publish-version
       if: inputs.publish-version == 'true'

--- a/actions/deploy-lambda-function/action.yml
+++ b/actions/deploy-lambda-function/action.yml
@@ -68,7 +68,7 @@ runs:
     #   An update is in progress for resource: arn:aws:lambda:<region>:***:function:<redacted>
     - name: 'Let the function settle'
       shell: bash
-      run: sleep 10 # seconds
+      run: sleep 5 # seconds
 
     - name: 'Cut a version of the lambda'
       id: publish-version


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

```
An error occurred (ResourceConflictException) when calling the PublishVersion operation: The operation cannot be performed at this time.  An update is in progress for resource: arn:aws:lambda:<region>:***:function:<redacted>
```

## Solution

<!-- How does this change fix the problem? -->

Sleep for a few seconds before attempting to publish a new version.

## Notes

<!-- Additional notes here -->

Not sure if steps can issue retries, but if they can, maybe we can have it attempt to publish the lambda 3 times.