### PR TITLE
Sets the ref back to v3 in the deploy-lambda-function workflow

### DIFF
--- a/.github/workflows/deploy-lambda-function.yml
+++ b/.github/workflows/deploy-lambda-function.yml
@@ -198,7 +198,7 @@ jobs:
       # deploy
       - name: 'Deploy'
         id: deploy
-        uses: shopsmart/github-actions/actions/deploy-lambda-function@feature/lambda-update-alias
+        uses: shopsmart/github-actions/actions/deploy-lambda-function@v3
         with:
           zip-file: ${{ inputs.pattern }}
           function-name: ${{ inputs.function-name }}


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

I forgot to remove my reference to the feature branch in the shared workflow.

## Solution

<!-- How does this change fix the problem? -->

Removes the reference to my branch for testing purposes and puts back to v3.

## Notes

<!-- Additional notes here -->
