### PR TITLE
Adds dependabot config to upgrade github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,10 @@ updates:
       - "maintenance"
       - "dependencies"
     groups:
-      patterns:
-        - ".*"
-      exclude-patterns:
-        # These actions require major release updates
-        - "actions/upload-artifact"
-        - "actions/download-artifact"
+      all-actions:
+        patterns:
+          - ".*"
+        exclude-patterns:
+          # These actions require major release updates
+          - "actions/upload-artifact"
+          - "actions/download-artifact"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    labels:
+      - "maintenance"
+      - "dependencies"
+    groups:
+      patterns:
+        - ".*"
+      exclude-patterns:
+        # These actions require major release updates
+        - "actions/upload-artifact"
+        - "actions/download-artifact"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,0 @@
-{
-    "enabledManagers": [
-        "github-actions"
-    ]
-}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,5 @@
+{
+    "enabledManagers": [
+        "github-actions"
+    ]
+}


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

We would like to update all github-actions and have them keep up-to-date.

## Solution

<!-- How does this change fix the problem? -->

Adds a dependabot config to update actions weekly.  All actions will be updated in one group PR.

actions/upload-artifact and actions/download-artifact will be updated in individual PRs since upgrading them can cause breaking changes.

## Notes

<!-- Additional notes here -->

This will probably need some fine tuning, but this gets us started.
