### PR TITLE
Corrects wildcard pattern in the dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,12 @@ updates:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
     labels:
-      - "maintenance"
       - "dependencies"
     groups:
       all-actions:
+        applies-to: version-updates
         patterns:
-          - ".*"
+          - "*"
         exclude-patterns:
           # These actions require major release updates
           - "actions/upload-artifact"


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

I setup the dependabot config incorrectly and the PRs are not being grouped.

## Solution

<!-- How does this change fix the problem? -->

Updates the wildcard syntax.

## Notes

<!-- Additional notes here -->

Also removes the maintenance label since it does not exist.
