### PR TITLE
Configure dependabot to cover actions/ and .github/actions/

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,11 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions"
+      - "/.github/workflows"
+      - "/actions"
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

Dependabot is properly grouping our PRs and secrets have been filled in for it to run our automation.  The only problem is that it is only updating workflows.

## Solution

<!-- How does this change fix the problem? -->

As such, we will explicitly request actions/ and .github/actions/ to be updated as well.

## Notes

<!-- Additional notes here -->
