### PR TITLE
Update actions/*-artifact actions in an independent group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,12 +12,35 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+    ignore:
+      - dependency-name: 'actions/upload-artifact'
+      - dependency-name: 'actions/download-artifact'
     groups:
       all-actions:
         applies-to: version-updates
         patterns:
           - "*"
-        exclude-patterns:
-          # These actions require major release updates
-          - "actions/upload-artifact"
-          - "actions/download-artifact"
+
+  # Artifact actions causing breaking changes.  When this repo updates the upload-artifact action,
+  #   the consuming repo must also update the download-artifact action and vice-versa.
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+      - "/.github/actions/**"
+      - "/actions/**"
+    schedule:
+      # Check for updates to Github Actions every week
+      interval: "weekly"
+    labels:
+      - "breaking changes"
+      - "dependencies"
+    ignore:
+      - dependency-name: '*'
+    allow:
+      - dependency-name: 'actions/upload-artifact'
+      - dependency-name: 'actions/download-artifact'
+    groups:
+      artifact-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

The `actions/*-artifact` actions updates are not backwards-compatible.  This is because when you upload an artifact on one version, the download artifact must be the same version.

## Solution

<!-- How does this change fix the problem? -->

Completely ignore the `actions/*-artifact` actions in the all-actions group and create a separate update for just the artifact actions.  This will also tag the PR with `breaking changes`.

## Notes

<!-- Additional notes here -->

