### PR TITLE
Creates a separate group for artifact actions rather than an update object

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,10 @@ updates:
         patterns:
           - "*"
         exclude-patterns:
-          # These actions require major release updates
-          - "actions/upload-artifact"
-          - "actions/download-artifact"
+          - "actions/*-artifact"
+      # Artifact actions causing breaking changes.  When this repo updates the upload-artifact action,
+      #   the consuming repo must also update the download-artifact action and vice-versa.
+      artifact-actions:
+        applies-to: version-updates
+        patterns:
+          - "actions/*-artifact"


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

Despite that the dependabot config check passed, we cannot have overlapping package-ecosystems with the same paths.

## Solution

<!-- How does this change fix the problem? -->

Removes the "artifact-actions" update object and adds a group targetting the actions instead.

## Notes

<!-- Additional notes here -->
