### PR TITLE
Updates all actions/*-artifact actions from 3 to 4

### DIFF
--- a/.github/actions/test-render-task-definition/action.yml
+++ b/.github/actions/test-render-task-definition/action.yml
@@ -22,7 +22,7 @@ runs:
       uses: actions/checkout@v4
 
     - name: 'Download task-definition'
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: task-definition-renamed
 

--- a/.github/workflows/deploy-lambda-function.yml
+++ b/.github/workflows/deploy-lambda-function.yml
@@ -179,7 +179,7 @@ jobs:
         if: inputs.release-tag != ''
 
       - name: 'Pull artifact'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}
         # Only if we are pulling from an artifact

--- a/.github/workflows/register-task-definition.yml
+++ b/.github/workflows/register-task-definition.yml
@@ -210,7 +210,7 @@ jobs:
         continue-on-error: ${{ inputs.allow-datadog-to-fail }}
 
       - name: 'Download task-definition'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}
 

--- a/.github/workflows/render-task-definition.yml
+++ b/.github/workflows/render-task-definition.yml
@@ -164,7 +164,7 @@ jobs:
           output: ${{ inputs.output }}
 
       - name: 'Upload task definition'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}
           path: ${{ steps.render.outputs.file }}

--- a/.github/workflows/test-deploy-lambda-function-workflow.yml
+++ b/.github/workflows/test-deploy-lambda-function-workflow.yml
@@ -37,7 +37,7 @@ jobs:
           zip archive.zip ./index.js
 
       - name: 'Upload the archive file'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: lambda-function
           path: .github/actions/test-deploy-lambda-function-workflow/archive.zip

--- a/.github/workflows/test-register-task-definition.yml
+++ b/.github/workflows/test-register-task-definition.yml
@@ -33,7 +33,7 @@ jobs:
           sed -i.bak 's/{{ account_id }}/${{ secrets.AWS_ACCOUNT_ID }}/g' '${{ env.ACTION_PATH }}/task-definition.yml'
 
       - name: 'Upload task definition file'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: task-definition-renamed
           path: ${{ env.ACTION_PATH }}/task-definition.yml


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

We would like all actions to be up-to-date.

## Solution

<!-- How does this change fix the problem? -->

Though we have dependabot running to update these actions, a new group was created for artifact-actions but dependabot thinks they are to be ignored since I closed out the old PRs.

## Notes

<!-- Additional notes here -->



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208939598640951