### PR TITLE
Adds dependabot config to update Github Actions on a weekly basis

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,26 +5,13 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "/"
-      - "/.github/actions/**"
-      - "/actions/**"
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
     labels:
       - "dependencies"
-    ignore:
-      - dependency-name: 'actions/upload-artifact'
-      - dependency-name: 'actions/download-artifact'
     groups:
-      all-actions:
+      github-actions:
         applies-to: version-updates
         patterns:
           - "*"
-        exclude-patterns:
-          - "actions/*-artifact"
-      # Artifact actions causing breaking changes.  When this repo updates the upload-artifact action,
-      #   the consuming repo must also update the download-artifact action and vice-versa.
-      artifact-actions:
-        applies-to: version-updates
-        patterns:
-          - "actions/*-artifact"


### PR DESCRIPTION
## Problem

We would like our Github Actions to remain up-to-date.

## Solution

Adds a dependabot config to update all Github Actions on a weekly basis grouping them into a single PR.

