### PR TITLE
Allows the cache control to be set when deploying to an s3 bucket

### DIFF
--- a/.github/actions/test-deploy-to-s3-bucket/action.yml
+++ b/.github/actions/test-deploy-to-s3-bucket/action.yml
@@ -45,6 +45,7 @@ runs:
         pattern: 'archive.tgz'
         s3-bucket: shopsmart-github-actions-tests
         s3-bucket-path: ${{ steps.id.outputs.id }}
+        cache-control: max-age=3600
 
     - name: 'Validate'
       shell: bash
@@ -52,3 +53,4 @@ runs:
       env:
         S3_BUCKET: shopsmart-github-actions-tests
         S3_BUCKET_PATH: ${{ steps.id.outputs.id }}
+        CACHE_CONTROL: max-age=3600

--- a/.github/actions/test-deploy-to-s3-bucket/deploy-to-s3-bucket.bats
+++ b/.github/actions/test-deploy-to-s3-bucket/deploy-to-s3-bucket.bats
@@ -34,4 +34,13 @@ function teardown() {
 
   [ "$status" -eq 0 ]
   [[ "$output" =~ $S3_TAG ]]
+
+  run aws s3api head-object --no-cli-pager \
+    --bucket "$S3_BUCKET" \
+    --key "$S3_BUCKET_PATH/style.css" \
+    --query 'CacheControl' \
+    --output text
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$CACHE_CONTROL" ]
 }

--- a/actions/deploy-to-s3-bucket/action.yml
+++ b/actions/deploy-to-s3-bucket/action.yml
@@ -34,6 +34,10 @@ inputs:
           owner=carl
     default: ''
 
+  cache-control:
+    description: 'Sets the cache-control headers for the content being uploaded'
+    default: ''
+
 runs:
   using: 'composite'
   steps:
@@ -58,6 +62,7 @@ runs:
       env:
         S3_BUCKET: ${{ inputs.s3-bucket }}
         S3_BUCKET_PATH: ${{ inputs.s3-bucket-path }}
+        CACHE_CONTROL: ${{ inputs.cache-control }}
 
     - name: 'Tag assets'
       shell: bash

--- a/actions/deploy-to-s3-bucket/upload-assets.bats
+++ b/actions/deploy-to-s3-bucket/upload-assets.bats
@@ -12,6 +12,8 @@ function setup() {
 
 function teardown() {
   rm -f "$AWS_CMD_FILE"
+
+  unset CACHE_CONTROL
 }
 
 function aws() {
@@ -34,4 +36,14 @@ function aws() {
   [ "$status" -eq 0 ]
   [ -f "$AWS_CMD_FILE" ]
   [[ "$(< "$AWS_CMD_FILE")" == s3\ cp\ --recursive\ my-path/\ s3://my-s3-bucket/my-s3-path/ ]]
+}
+
+@test "it should set the cache-control" {
+  export CACHE_CONTROL='max-age=36000'
+
+  run upload-assets my-path
+
+  [ "$status" -eq 0 ]
+  [ -f "$AWS_CMD_FILE" ]
+  [[ "$(< "$AWS_CMD_FILE")" == s3\ cp\ --recursive\ my-path/\ s3://my-s3-bucket/\ --cache-control\ max-age=36000 ]]
 }

--- a/actions/deploy-to-s3-bucket/upload-assets.sh
+++ b/actions/deploy-to-s3-bucket/upload-assets.sh
@@ -8,8 +8,14 @@ function upload-assets() {
   local s3_path="$S3_BUCKET"
   [ -z "${S3_BUCKET_PATH:-}" ] || s3_path+="/$S3_BUCKET_PATH"
 
+  local args=()
+
+  if [ -n "${CACHE_CONTROL:-}" ]; then
+    args+=(--cache-control "$CACHE_CONTROL")
+  fi
+
   echo "[DEBUG] Copying $path/ to s3://$s3_path/" >&2
-  aws s3 cp --recursive "$path/" "s3://$s3_path/"
+  aws s3 cp --recursive "$path/" "s3://$s3_path/" "${args[@]}"
 }
 
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

We would like to set the cache-control metadata when uploading a file to s3.

## Solution

<!-- How does this change fix the problem? -->

Allows the cache-control metadata to be specified when uploading artifacts to s3.

## Notes

<!-- Additional notes here -->
