### PR TITLE
Always pass the SHA when rendering task definitions

### DIFF
--- a/.github/workflows/render-task-definition.yml
+++ b/.github/workflows/render-task-definition.yml
@@ -116,6 +116,10 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      - name: 'Resolve the sha'
+        id: sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: 'Setup python'
         uses: actions/setup-python@v5
         with:
@@ -157,6 +161,7 @@ jobs:
           format-options: ${{ inputs.format-options }}
           environment: |
             TAG=${{ inputs.ref }}
+            SHA=${{ steps.sha.outputs.sha }}
             AWS_ACCOUNT_ID=${{ secrets.aws-account-id }}
             AWS_REGION=${{ inputs.aws-region }}
             ${{ inputs.environment }}


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

We would like to start attaching the github sha to the task definitions.

## Solution

<!-- How does this change fix the problem? -->

Resolves and passes the github sha to the rendering of the task definition.

## Notes

<!-- Additional notes here -->

One can override this value by setting:

```yaml
environment: |
  SHA=<your-sha-value>
```
