### PR TITLE
Pins the action-gh-release action to 2.2.2

### DIFF
--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -407,7 +407,7 @@ jobs:
 
       - name: 'Upload docker image'
         if: (inputs.skip-if-exists == false || steps.already-exists.outputs.answer == 'false') && steps.is-gh-release.outputs.is-release == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         with:
           tag_name: ${{ inputs.ref }}
           files: docker-image-*.tgz


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

v2.3.0 is broken for action-gh-release.

## Solution

<!-- How does this change fix the problem? -->

Rolling back to v2.2.2 in the meantime.

## Notes

<!-- Additional notes here -->

https://github.com/softprops/action-gh-release/issues/627
https://github.com/softprops/action-gh-release/issues/628