### PR TITLE
Re-tags a docker image when the image already exists, but tags were provided

### DIFF
--- a/.github/actions/test-build-ecr-image/action.yml
+++ b/.github/actions/test-build-ecr-image/action.yml
@@ -10,6 +10,10 @@ inputs:
   ref:
     description: 'The github ref to expect'
     required: false
+  version-string:
+    description: 'The version string that was used as a build-arg.  This normally is just the ref of the docker image, but when re-tagging, it would take whatever version is already built.'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -42,3 +46,4 @@ runs:
       env:
         ECR_REPOSITORY: ${{ inputs.aws-account-id }}.dkr.ecr.us-east-1.amazonaws.com/github-actions-tests
         VERSION_TAG: ${{ inputs.ref }}
+        VERSION_STRING: ${{ input.version-string || inputs.ref }}

--- a/.github/actions/test-retag-docker-image/action.yml
+++ b/.github/actions/test-retag-docker-image/action.yml
@@ -1,0 +1,42 @@
+---
+
+name: 'Test retag-docker-image action'
+description: 'Runs validation agains the retag-docker-image action'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Setup Homebrew'
+      uses: Homebrew/actions/setup-homebrew@master
+
+    - name: 'Install BATS'
+      shell: bash
+      run: brew install bats-core
+
+    - name: 'Checkout'
+      uses: actions/checkout@v4
+
+    - name: 'Use local actions'
+      uses: ./.github/actions/use-local-actions
+
+    - name: 'Configure AWS Credentials'
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: 'us-east-1'
+        role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/github-actions-tests
+
+    - name: 'Re-tag docker image'
+      id: retag
+      uses: ./actions/retag-docker-image
+      with:
+        source: 'scratch:latest'
+        targets: |
+          ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/github-actions-tests:${{ github.run_id }}-variant1
+          ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/github-actions-tests:${{ github.run_id }}-variant2
+
+    - name: 'Validate'
+      shell: bash
+      run: bats -r ${{ github.action_path }}/retag-docker-image.bats
+      env:
+        TARGET_IMAGE_VARIANT1: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/github-actions-tests:${{ github.run_id }}-variant1
+        TARGET_IMAGE_VARIANT2: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/github-actions-tests:${{ github.run_id }}-variant2

--- a/.github/actions/test-retag-docker-image/retag-docker-image.bats
+++ b/.github/actions/test-retag-docker-image/retag-docker-image.bats
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+
+@test "it have retagged the docker image as variant1" {
+  docker pull "$TARGET_IMAGE_VARIANT1"
+  [ "$status" -eq 0 ]
+}
+
+@test "it have retagged the docker image as variant2" {
+  docker pull "$TARGET_IMAGE_VARIANT2"
+  [ "$status" -eq 0 ]
+}

--- a/.github/workflows/build-ecr-image.yml
+++ b/.github/workflows/build-ecr-image.yml
@@ -344,8 +344,8 @@ jobs:
           use: ${{ inputs.use }}
           endpoint: ${{ inputs.endpoint }}
           platforms: ${{ inputs.platforms }}
-          config: ${{ inputs.config }}
-          config-inline: ${{ inputs.config-inline }}
+          buildkitd-config: ${{ inputs.config }}
+          buildkitd-config-inline: ${{ inputs.config-inline }}
           append: ${{ inputs.append }}
 
       - name: 'Build docker image'
@@ -393,8 +393,17 @@ jobs:
           ulimit: ${{ inputs.ulimit }}
           github-token: ${{ secrets.github-token || github.token }}
 
+      - name: 'Tag docker image'
+        if: inputs.skip-if-exists == 'true' || steps.already-exists.outputs.answer == 'true'
+        uses: shopsmart/github-actions/actions/retag-docker-image@DEV-690/do-not-build-docker-image-when-already-built
+        with:
+          source: ${{ env.DOCKER_IMAGE }}:${{ steps.sha.outputs.sha }}
+          targets: |
+            ${{ steps.additional-tag.outputs.tag }}
+            ${{ inputs.tags }}
+
       - name: 'Pull and package docker image'
-        if: (inputs.skip-if-exists == false || steps.already-exists.outputs.answer == 'false') && steps.is-gh-release.outputs.is-release == 'true'
+        if: steps.is-gh-release.outputs.is-release == 'true'
         env:
           NAME: ${{ inputs.repository-name }}
           IMAGE: ${{ env.DOCKER_IMAGE }}:${{ steps.sha.outputs.sha }}
@@ -406,7 +415,7 @@ jobs:
           docker save "$IMAGE" | gzip > "docker-image-$NAME-$TAG.tgz"
 
       - name: 'Upload docker image'
-        if: (inputs.skip-if-exists == false || steps.already-exists.outputs.answer == 'false') && steps.is-gh-release.outputs.is-release == 'true'
+        if: steps.is-gh-release.outputs.is-release == 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.ref }}

--- a/.github/workflows/test-build-ecr-image.yml
+++ b/.github/workflows/test-build-ecr-image.yml
@@ -104,3 +104,32 @@ jobs:
       skip-if-exists: true
     secrets:
       aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
+
+  # Re-tag the docker image if it already exists
+  run-build-ecr-image-retag-if-exists:
+    needs: run-build-ecr-image-skip-if-exists # The image has to have been created previously
+    uses: ./.github/workflows/build-ecr-image.yml
+    with:
+      file: .github/actions/test-build-ecr-image/Dockerfile
+      repository-name: github-actions-tests
+      role-name: github-actions-tests
+      tags: |
+        ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/github-actions-tests:${{ github.run_id }}
+      ref: ${{ github.sha }}
+      skip-if-exists: true
+    secrets:
+      aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
+
+  test-build-ecr-image-retag-if-exists:
+    runs-on: ubuntu-latest
+    needs: run-build-ecr-image-workflow
+    steps:
+      - name: 'Checkout actions'
+        uses: actions/checkout@v4
+
+      - name: 'Test build-ecr-image workflow'
+        uses: ./.github/actions/test-build-ecr-image
+        with:
+          aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
+          ref: ${{ github.run_id }}
+          version-string: ${{ github.sha }}

--- a/.github/workflows/test-retag-docker-image.yml
+++ b/.github/workflows/test-retag-docker-image.yml
@@ -1,0 +1,22 @@
+---
+name: 'Run retag-docker-image action'
+
+on:
+  pull_request:
+    paths:
+      - actions/retag-docker-image/*
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test-retag-docker-image-action:
+    name: 'Uses the retag-docker-image action'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout actions'
+        uses: actions/checkout@v4
+
+      - name: 'Test retag-docker-image action'
+        uses: ./.github/actions/test-retag-docker-image

--- a/actions/retag-docker-image/action.yml
+++ b/actions/retag-docker-image/action.yml
@@ -1,0 +1,37 @@
+---
+name: 'Retag Docker Image'
+description: |
+  Retag a Docker image with a new tag.
+
+inputs:
+  source:
+    description: 'The source Docker image and tag to retag'
+    required: true
+
+  targets:
+    description: |
+      The target Docker image and tags to apply.
+      Multiple tags can be specified as a line-delimited list.
+
+      Example:
+        targets: |
+          myregistry/myimage:latest
+          myregistry/myimage:v1.0.0
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Retag Docker Image'
+      run: ${{ github.action_path }}/scripts/retag-docker-image.sh ${{ inputs.source }}
+      shell: bash
+      env:
+        TARGETS: ${{ inputs.targets }}
+
+    - name: 'Output Retagged Images'
+      run: |
+        echo "Retagged images:"
+        for target in ${{ inputs.targets }}; do
+          echo "- $target"
+        done
+      shell: bash

--- a/actions/retag-docker-image/retag-docker-image.bats
+++ b/actions/retag-docker-image/retag-docker-image.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+
+load retag-docker-image.sh
+
+function docker() {
+  echo "docker $*" >> "$DOCKER_CMD_FILE"
+}
+
+function setup() {
+  export DOCKER_CMD_FILE="$BATS_TEST_TMPDIR/docker.cmd"
+
+  export -f docker
+}
+
+function teardown() {
+  rm -f "$DOCKER_CMD_FILE"
+}
+
+@test "should error out if no source image is provided" {
+  run retag-docker-image
+
+  [ "$status" -ne 0 ]
+  [ "${lines[0]}" = "Usage: $0 <source-image> [<target-image1> <target-image2> ...]" ]
+}
+
+@test "should not error out if no target images are provided" {
+  run retag-docker-image "source-image"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "should retag a single target image" {
+  run retag-docker-image "source-image" "target-image"
+
+  [ "$status" -eq 0 ]
+  [ -f "$DOCKER_CMD_FILE" ]
+  [ "$(< "$DOCKER_CMD_FILE")" = "docker tag source-image target-image" ]
+}
+
+@test "should retag multiple target images" {
+  run retag-docker-image "source-image" "target-image1" "target-image2"
+
+  [ "$status" -eq 0 ]
+  [ -f "$DOCKER_CMD_FILE" ]
+  [[ "$(< "$DOCKER_CMD_FILE")" =~ "docker tag source-image target-image1".* ]]
+  [[ "$(< "$DOCKER_CMD_FILE")" =~ .*"docker tag source-image target-image2" ]]
+}
+
+@test "should read target images from TARGETS environment variable" {
+  export TARGETS="target-image1
+target-image2"
+
+  run retag-docker-image "source-image"
+
+  [ "$status" -eq 0 ]
+  [ -f "$DOCKER_CMD_FILE" ]
+  [[ "$(< "$DOCKER_CMD_FILE")" =~ "docker tag source-image target-image1".* ]]
+  [[ "$(< "$DOCKER_CMD_FILE")" =~ .*"docker tag source-image target-image2" ]]
+}

--- a/actions/retag-docker-image/retag-docker-image.sh
+++ b/actions/retag-docker-image/retag-docker-image.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+function retag-docker-image() {
+  local source="$1"
+  shift || :
+
+  local targets=("$@")
+  if [ ${#targets[@]} -eq 0 ]; then
+    # Read targets from the TARGETS environment variable if no arguments are provided
+    while read -r target; do
+      [ -n "$target" ] || continue
+      targets+=("$target")
+    done <<< "${TARGETS:-}"
+  fi
+
+  if [ -z "$source" ]; then
+    echo "Usage: $0 <source-image> [<target-image1> <target-image2> ...]"
+    return 1
+  fi
+
+  if [ ${#targets[@]} -eq 0 ]; then
+    echo "[INFO ] No target images specified." >&2
+    return 0
+  fi
+
+  for target in "${targets[@]}"; do
+    [ -n "$target" ] || continue
+
+    echo "Retagging $source to $target..." >&2
+    docker tag "$source" "$target"
+  done
+}
+
+if [ "$0" = "${BASH_SOURCE[0]}" ]; then
+  set -eo pipefail
+  retag-docker-image "${@:-}"
+  exit $?
+fi


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

When the docker image already exists and the layers are immutable, one may just want to re-tag an existing image.

Example:

`v1.2.0-rc.0` is cut from github sha: `f8eea1aee3dbfc2bdbf00c23dc47204c968438be`.

```yaml
with:
  ref: v1.2.0-rc.0
  skip-if-exists: true
```

will publish docker tags for `f8eea1aee3dbfc2bdbf00c23dc47204c968438be` and `v1.2.0-rc.0`.


Next, a `v1.2.0` is cut from the sha.

```yaml
with:
  ref: v1.2.0
  skip-if-exists: true
```

Because `skip-if-exists` is set, it will see that `f8eea1aee3dbfc2bdbf00c23dc47204c968438be` already exists and stop executing.

## Solution

<!-- How does this change fix the problem? -->

If the docker is skipped because it already exists, it will now attempt to re-tag that same docker image with all of the tags provided.

## Notes

<!-- Additional notes here -->

